### PR TITLE
feat: refresh UX copy and skills around AI-fluent positioning

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,10 +4,10 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="description" content="Hiroyuki Kuwana - Full Stack Developer & Creative Problem Solver. Building elegant solutions with modern web technologies." />
-		<meta name="keywords" content="Hiroyuki Kuwana, Full Stack Developer, Web Developer, Software Engineer, Vue, Svelte, Python" />
-		<meta property="og:title" content="Hiroyuki Kuwana | Full Stack Developer" />
-		<meta property="og:description" content="Building elegant solutions with modern web technologies." />
+		<meta name="description" content="Hiroyuki Kuwana builds AI-fluent products in TypeScript, Svelte, Python, and LLM systems. Shipping software since 2018." />
+		<meta name="keywords" content="Hiroyuki Kuwana, AI engineer, product builder, TypeScript, Svelte, Python, LLM, full stack" />
+		<meta property="og:title" content="Hiroyuki Kuwana | AI-fluent product builder" />
+		<meta property="og:description" content="AI-fluent design that augments you, not another chatbot. Building since 2018 in TypeScript, Svelte, Python, and LLMs." />
 		<meta property="og:type" content="website" />
 		<link rel="preconnect" href="https://fonts.googleapis.com">
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/lib/components/About.svelte
+++ b/src/lib/components/About.svelte
@@ -1,54 +1,52 @@
 <script>
 	const skills = [
 		{
-			category: 'Frontend',
-			items: ['Svelte/SvelteKit', 'Vue.js', 'React', 'TypeScript', 'HTML/CSS', 'Tailwind']
+			category: 'AI & LLMs',
+			items: ['Claude / GPT', 'RAG pipelines', 'Tool-use agents', 'Evals', 'Prompt design', 'Streaming UX']
+		},
+		{
+			category: 'TypeScript & Svelte',
+			items: ['SvelteKit 5', 'TypeScript', 'Vite', 'Tailwind']
 		},
 		{
 			category: 'Backend',
-			items: ['Python', 'Node.js', 'Firebase', 'PostgreSQL', 'REST APIs', 'GraphQL']
-		},
-		{
-			category: 'Tools',
-			items: ['Git', 'Docker', 'VS Code', 'Figma', 'Linux', 'CI/CD']
+			items: ['Python', 'Node.js', 'Supabase', 'PostgreSQL', 'REST APIs', 'GraphQL', 'Edge runtimes']
 		}
 	];
 
 	const stats = [
-		{ value: '5+', label: 'Projects Completed' },
-		{ value: '3+', label: 'Years Experience' },
-		{ value: '100%', label: 'Client Satisfaction' }
+		{ value: '2018', label: 'Shipping since' },
+		{ value: 'TS · Py', label: 'Daily stack' },
+		{ value: 'LLM-native', label: 'How I build' }
 	];
 </script>
 
 <section id="about" class="about section">
 	<div class="container">
 		<div class="about-header">
-			<span class="section-label">About Me</span>
-			<h2 class="section-title">Passionate Developer,<br/>Creative Problem Solver</h2>
+			<span class="section-label">About</span>
+			<h2 class="section-title">Engineer who designs.<br/>Designer who ships.</h2>
 			<p class="section-subtitle">
-				I believe in building software that makes a difference — combining technical excellence
-				with user-centered design.
+				I build software that augments people instead of replacing their judgment. Real
+				interfaces, real systems, real outcomes.
 			</p>
 		</div>
 
 		<div class="about-grid">
 			<div class="about-story card">
-				<h3>My Journey</h3>
+				<h3>How I work</h3>
 				<p>
-					I'm a Brown University graduate ('21) who discovered my passion for web development
-					during a time when the world was changing rapidly. What started as curiosity about
-					how websites work evolved into a deep commitment to crafting exceptional digital experiences.
+					I started shipping code in 2018 as an intern, kept shipping through Brown ('21),
+					and now build product end-to-end: research, design, frontend, API, infra.
 				</p>
 				<p>
-					I approach every project with compassion and understanding, believing that the best
-					solutions come from truly understanding the people who will use them. My philosophy
-					is simple: technology should empower, not complicate.
+					LLMs entered my stack the day they were useful. I treat them like a teammate with
+					blind spots: useful for grunt work, terrible at judgment, and the best leverage I
+					have for prototyping new interfaces before I commit to them.
 				</p>
 				<p>
-					When I'm not coding, you'll find me exploring new technologies, contributing to
-					open-source projects, or enjoying the outdoors. I'm always eager to learn and
-					take on new challenges.
+					I care about the seam between people and software. The model should fade into
+					the product. The product should fade into the work. That is the bar.
 				</p>
 			</div>
 

--- a/src/lib/components/BlogPreview.svelte
+++ b/src/lib/components/BlogPreview.svelte
@@ -39,10 +39,11 @@
 	<div class="container">
 		<div class="blog-header">
 			<div class="header-content">
-				<span class="section-label">Blog</span>
-				<h2 class="section-title">Latest Articles</h2>
+				<span class="section-label">Writing</span>
+				<h2 class="section-title">Notes from the workbench</h2>
 				<p class="section-subtitle">
-					Thoughts, tutorials, and insights on web development, technology, and beyond.
+					Short pieces on building with LLMs, the tools I use daily, and what stops being
+					true the more you ship.
 				</p>
 			</div>
 			<a href="/blog" class="btn btn-secondary view-all">

--- a/src/lib/components/Contact.svelte
+++ b/src/lib/components/Contact.svelte
@@ -50,19 +50,19 @@
 	<div class="container">
 		<div class="contact-header">
 			<span class="section-label">Contact</span>
-			<h2 class="section-title">Let's Work Together</h2>
+			<h2 class="section-title">Want to build something?</h2>
 			<p class="section-subtitle">
-				Have a project in mind or just want to chat? I'm always excited to hear about
-				new opportunities and interesting ideas.
+				If you have a product that should think with you instead of at you, I want to hear
+				about it. Short notes welcome.
 			</p>
 		</div>
 
 		<div class="contact-grid">
 			<div class="contact-info">
-				<h3>Get in Touch</h3>
+				<h3>Reach out</h3>
 				<p class="info-text">
-					Whether you're looking for a developer to bring your vision to life,
-					have questions about my work, or just want to say hello — my inbox is always open.
+					Hiring, collaborating, or just want to compare notes on AI-fluent product work?
+					Email is the fastest path. I read every message.
 				</p>
 
 				<div class="info-items">

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -23,7 +23,7 @@
 					<span class="logo-text">HK</span>
 					<span class="logo-dot"></span>
 				</a>
-				<p class="tagline">Building elegant solutions with modern web technologies.</p>
+				<p class="tagline">AI-fluent product builder. Shipping since 2018.</p>
 			</div>
 
 			<div class="footer-links">

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -23,7 +23,7 @@
 		<div class="hero-content">
 			<div class="hero-badge">
 				<span class="status-dot"></span>
-				Available for new projects
+				Building since 2018, open to new work
 			</div>
 
 			<h1 class="hero-title">
@@ -32,8 +32,8 @@
 			</h1>
 
 			<p class="hero-subtitle">
-				Full Stack Developer crafting <em>elegant solutions</em> with modern web technologies.
-				I transform complex problems into intuitive, performant applications.
+				<em>AI-fluent design</em> that augments you, not another chatbot. I build products in
+				TypeScript, Svelte, Python, and LLM systems, treating the model as a teammate, not a feature.
 			</p>
 
 			<div class="hero-cta">
@@ -76,12 +76,12 @@
 				<div class="image-border"></div>
 			</div>
 			<div class="floating-card card-1">
-				<span class="card-icon">🎓</span>
-				<span class="card-text">Brown '21</span>
+				<span class="card-icon">↳</span>
+				<span class="card-text">Shipping since 2018</span>
 			</div>
 			<div class="floating-card card-2">
-				<span class="card-icon">💻</span>
-				<span class="card-text">5+ Projects</span>
+				<span class="card-icon">◈</span>
+				<span class="card-text">LLMs · TS · Svelte · Py</span>
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/Projects.svelte
+++ b/src/lib/components/Projects.svelte
@@ -48,11 +48,11 @@
 <section id="projects" class="projects section">
 	<div class="container">
 		<div class="projects-header">
-			<span class="section-label">My Work</span>
-			<h2 class="section-title">Featured Projects</h2>
+			<span class="section-label">Work</span>
+			<h2 class="section-title">Selected projects</h2>
 			<p class="section-subtitle">
-				A selection of projects that showcase my skills in full-stack development,
-				from concept to deployment.
+				Things I shipped end-to-end. Each one solves a real problem; AI is a means, not the
+				marketing.
 			</p>
 		</div>
 

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -69,16 +69,17 @@
 
 <svelte:head>
 	<title>Blog | Hiroyuki Kuwana</title>
-	<meta name="description" content="Articles about web development, software engineering, and technology by Hiroyuki Kuwana." />
+	<meta name="description" content="Short pieces on building with LLMs, the tools I use daily, and what stops being true the more you ship — by Hiroyuki Kuwana." />
 </svelte:head>
 
 <section class="blog-page">
 	<div class="container">
 		<header class="blog-header">
-			<span class="section-label">Blog</span>
-			<h1>Thoughts & Tutorials</h1>
+			<span class="section-label">Writing</span>
+			<h1>Notes from the workbench</h1>
 			<p class="subtitle">
-				Exploring web development, software engineering, and the technologies that power the modern web.
+				Short pieces on building with LLMs, the tools I use daily, and what stops being true
+				the more you ship.
 			</p>
 		</header>
 


### PR DESCRIPTION
Rewrite site copy across Hero, About, Projects, BlogPreview, Contact, Footer, app.html SEO tags, and the /blog page header + meta description to lead with AI-fluent product work and a "shipping since 2018" frame. Restructure About skill categories into AI & LLMs, TypeScript & Svelte, and Backend, and replace the projects/years/satisfaction stats with shipping-since/daily-stack/how-I-build.