### PR TITLE
feat: convert blog to markdown loader and add AI workflow articles

### DIFF
--- a/src/content/blog/building-better-apis.md
+++ b/src/content/blog/building-better-apis.md
@@ -1,0 +1,61 @@
+---
+title: "Building Better APIs: Best Practices for RESTful Design"
+date: 2024-01-08
+readTime: 6 min read
+excerpt: Learn how to design clean, intuitive, and scalable REST APIs that developers love to use. We cover naming conventions, versioning, error handling, and more.
+tags: [API, Backend, Best Practices]
+featured: true
+---
+
+A well-designed API is a joy to work with. It's intuitive, consistent, and makes developers productive. Let's explore the best practices that separate good APIs from great ones.
+
+## Use Nouns, Not Verbs
+
+Your endpoints should represent resources, not actions:
+
+```
+// Good
+GET /users
+POST /users
+GET /users/123
+
+// Bad
+GET /getUsers
+POST /createUser
+GET /getUserById
+```
+
+## Use HTTP Methods Correctly
+
+- **GET** : Retrieve resources
+- **POST** : Create new resources
+- **PUT** : Update entire resources
+- **PATCH** : Partial updates
+- **DELETE** : Remove resources
+
+## Version Your API
+
+Always version your API from day one:
+
+```
+https://api.example.com/v1/users
+https://api.example.com/v2/users
+```
+
+## Handle Errors Gracefully
+
+Provide meaningful error responses:
+
+```json
+{
+	"error": {
+		"code": "VALIDATION_ERROR",
+		"message": "Email is required",
+		"field": "email"
+	}
+}
+```
+
+## Conclusion
+
+Following these best practices will help you build APIs that developers love to use. Remember: the best API is one that's so intuitive, users barely need to read the documentation.

--- a/src/content/blog/claude-overnight-experiments.md
+++ b/src/content/blog/claude-overnight-experiments.md
@@ -1,0 +1,179 @@
+---
+title: "From Chat to Cron: Setting Up Claude as an Overnight Research Assistant"
+date: 2026-05-07
+readTime: 8 min read
+excerpt: For people who've used Claude in a chat window and wondered : can it just keep going on its own? Yes. Here is what to give it and what to take away.
+tags: [AI, Claude, Tutorial]
+featured: false
+---
+
+For people who've used Claude in a chat window and wondered: *can it just keep going on its own?*
+
+Yes. The trick is knowing what to give it (a clear job, a way to score itself, files it's allowed to touch) and what to take away (open-ended goals, unbounded edits, the option to ask you mid-run).
+
+This is a practical setup guide, not a theory paper. The goal: by the end of an evening, you have a loop that runs, edits one file at a time, and commits anything that improved a number you defined.
+
+## The mental model shift
+
+In chat, you and the model are co-authors. You write a turn, it writes a turn. The collaboration is the value.
+
+In a loop, the model is an unsupervised employee. The collaboration is gone. What replaces it:
+
+- **A precise job description** (the prompt or `program.md`).
+- **A way the employee can grade their own work** (a benchmark or test).
+- **A clear list of what they may and may not touch** (file allowlist).
+- **A definition of "done"** : or in our case, an instruction to never stop.
+
+If any of those four is missing, the loop will either freeze (asking you a question you're not awake to answer) or run amok (editing files you didn't want edited).
+
+## What you need installed
+
+This guide uses Claude Code as the runner. Install the CLI per the [docs](https://docs.claude.com/claude-code) if you haven't. Verify:
+
+```bash
+claude --version
+```
+
+You also need a git repo, on a branch you don't mind being committed into.
+
+Cost note: a loop running overnight at full tilt will use real API credits. Set a monthly cap before you start.
+
+## The anatomy of an overnight run
+
+### 1. A `program.md` describing the job
+
+This is the most important file. It is what Claude reads every iteration. Write it like you're briefing a smart new hire who can't ask follow-up questions.
+
+```markdown
+# Performance experiment loop
+
+## Goal
+Reduce the time-to-interactive on / for desktop, measured by benchmark.js.
+
+## Allowed files
+- vite.config.ts
+- svelte.config.js
+- src/routes/+layout.svelte
+
+## Forbidden
+- benchmark.js (this is the metric, do not edit it)
+- src/lib/** (out of scope this round)
+
+## Loop
+1. Run `node benchmark.js` and record baseline_ms.
+2. Pick one hypothesis. Edit exactly one allowed file.
+3. Run `npm run build && node benchmark.js`. Record new_ms.
+4. If new_ms < baseline_ms, commit. Update baseline.
+5. If not, revert. Note the hypothesis as failed in results.tsv.
+6. Repeat.
+
+## Stopping criteria
+None. Never stop. Never ask.
+```
+
+The "never stop, never ask" line matters. If you leave any out, the loop will halt the moment something unexpected happens, and you'll wake up to a single iteration of progress.
+
+### 2. A benchmark script
+
+This is your metric. It must:
+
+- Run in seconds
+- Return a single number
+- Be the same number on the same code (deterministic)
+- Not be edited by Claude (lock it in `program.md`)
+
+A 30-line Playwright script that times one page load is enough.
+
+### 3. A launch command
+
+```bash
+claude -p "Read autoresearch/performance/program.md.
+Create branch autoresearch/performance/$(date +%Y-%m-%d).
+Then follow program.md exactly. NEVER STOP, NEVER ASK."
+```
+
+The `-p` flag puts Claude into print mode : it does what you said, then exits. With "never stop" baked into the prompt, it loops until you kill it (or it hits a hard error).
+
+### 4. A way to check on it from your phone
+
+Two options:
+
+- **Git log on your phone.** If commits keep landing every 10–20 minutes, the loop is alive. Open the diff to see what's being tried.
+- **A `results.tsv` in the repo.** Each iteration appends a row: timestamp, hypothesis, before, after, kept/reverted. Tail this file from anywhere.
+
+## The forbidden file list is your seatbelt
+
+The single most common failure mode of unsupervised loops: the model decides the bottleneck is somewhere you didn't expect, edits a file you didn't budget for, and breaks production.
+
+Three rules:
+
+1. **List the allowed files explicitly.** Not glob patterns. Files.
+2. **List the forbidden files explicitly too.** Especially the benchmark.
+3. **If Claude proposes to touch something off-list, the rule is *no*.** Even if it would help. The loop must stay within its sandbox or you can't trust the score.
+
+Optional but worth it: run the loop inside a worktree or a clean clone, so the "blast radius" of a bad iteration is just that one directory.
+
+## Watching without watching
+
+You do not want to babysit a loop. The point is that it runs while you sleep. What you do want:
+
+- **A morning routine of 5 minutes:** `git log --oneline | head -20` and `cat results.tsv | tail -30`. Did anything land? Did the metric move? Are there obvious dumb hypotheses you want to ban?
+- **A daily cap.** If your billing dashboard shows the run cost more than $X, you stop and look at what it was doing.
+- **A "max wall-clock time" you walk away with.** 8 hours of overnight is plenty. After that, kill it and read.
+
+You are not optimizing the loop in real time. You are reading its output the next morning, and deciding whether to refine `program.md` for the next night. That's the actual collaboration.
+
+## What to run this on, first
+
+Don't pick "make my product better." That's not a loop, that's a wish.
+
+Good first loops:
+
+- **Bundle size.** Metric = output of `du -b dist/`. Allowed files = build config. Goal: reduce the number.
+- **Test runtime.** Metric = wall-clock of `npm test`. Allowed files = test setup, mock factories. Goal: shrink the number without dropping coverage.
+- **Lighthouse score on /.** Metric = JSON output of `lighthouse https://localhost:5173`. Allowed files = layout, image components.
+
+Each of these has a cheap, deterministic, locally-runnable score. That's what makes them loop-able.
+
+Bad first loops:
+
+- "Make the copy on the landing page convert better." (No local score.)
+- "Improve the onboarding." (Score is your users, who are not awake at 3am to be A/B-tested.)
+- "Refactor the codebase." (No objective metric. The loop will hill-climb arbitrary aesthetics.)
+
+If a loop topic doesn't have a clean number, it's not a loop topic. Yet. Maybe a chat session, maybe a feature flag and a bandit. Not an overnight run.
+
+## Common gotchas
+
+**Context bleed.** Long-running loops can lose track of what they've already tried. Have them append every attempt to `results.tsv` with a one-line summary. Tell them to read it before proposing the next hypothesis.
+
+**Rate limits.** Long runs hit them. Build in retries with exponential backoff. If the API is unreachable for >10 minutes, exit cleanly.
+
+**Infinite "thinking".** Some loops can get stuck in analysis without an edit. The fix: in `program.md`, require an actual file change every N minutes.
+
+**Cost.** If you don't cap, you can spend a hundred dollars overnight without noticing. Set a hard cap in your Anthropic dashboard. Re-set it monthly.
+
+**Hot branches.** Run the loop on its own branch. Never on `main`. If something goes wrong, you delete the branch. No cleanup required.
+
+## Your first 60-minute experiment
+
+Tonight, before you sleep:
+
+1. Pick a metric on your project that you can measure in 5 seconds with a script.
+2. Write `program.md`: goal, allowed files, forbidden files, the 6-step loop.
+3. Write the benchmark script. Verify it returns a number.
+4. Run `claude -p "Read program.md. Loop. Never stop, never ask."` in a tmux session.
+5. Walk away.
+6. In the morning, read `git log` and `results.tsv`.
+
+You will be surprised by something. Either it landed three real improvements and you're impressed, or it looped on one bad hypothesis all night, or it crashed at iteration 4 because of a rate limit.
+
+All three outcomes are useful. The point isn't that this loop is good : it's that *you now have the mechanic*. From here, every refinement is an edit to `program.md`.
+
+## What this is not
+
+This setup is not how you optimize user-facing copy, onboarding flow, or anything that requires a real human reading the output. Those need feature flags, real traffic, and patience.
+
+This setup *is* how you optimize anything with a real, local, fast, deterministic metric : performance, bundle size, test speed, build time, code-coverage. That covers a surprising amount of engineering work, and a loop will out-grind any human who tries to do it by hand.
+
+The shift in mindset: stop thinking about Claude as a smarter autocomplete, and start thinking about it as an unsupervised employee. Then ask: would you let an unsupervised employee touch this code with these instructions? If yes, loop it. If no, sharpen the instructions until yes.

--- a/src/content/blog/getting-started-with-svelte-5.md
+++ b/src/content/blog/getting-started-with-svelte-5.md
@@ -1,0 +1,58 @@
+---
+title: "Getting Started with Svelte 5: A Complete Guide"
+date: 2024-01-15
+readTime: 8 min read
+excerpt: Explore the new features in Svelte 5, including runes, fine-grained reactivity, and improved performance. This comprehensive guide will help you understand and leverage the power of Svelte 5 in your projects.
+tags: [Svelte, JavaScript, Tutorial]
+featured: true
+---
+
+Svelte 5 introduces a revolutionary new way to handle reactivity in your applications. With the introduction of runes, Svelte has evolved from a compiler-based framework to something even more powerful and intuitive.
+
+## What are Runes?
+
+Runes are special symbols that tell Svelte how to handle reactivity. The most important ones are:
+
+- `$state` : Declares reactive state
+- `$derived` : Creates computed values
+- `$effect` : Runs side effects when dependencies change
+- `$props` : Declares component props
+
+## Creating Reactive State
+
+In Svelte 5, you create reactive state using the `$state` rune:
+
+```js
+let count = $state(0);
+
+function increment() {
+	count++;
+}
+```
+
+## Derived Values
+
+When you need values that depend on other reactive values, use `$derived`:
+
+```js
+let count = $state(0);
+let doubled = $derived(count * 2);
+```
+
+## Side Effects
+
+The `$effect` rune replaces the old `$:` reactive statements for side effects:
+
+```js
+$effect(() => {
+	console.log('Count changed:', count);
+});
+```
+
+## Why This Matters
+
+These changes make Svelte more predictable and easier to reason about. The explicit nature of runes means you always know exactly what's reactive and what isn't.
+
+## Conclusion
+
+Svelte 5 represents a significant step forward for the framework. The new runes system provides more explicit control over reactivity while maintaining the simplicity that makes Svelte so approachable.

--- a/src/content/blog/implementing-karpathy-autoresearch.md
+++ b/src/content/blog/implementing-karpathy-autoresearch.md
@@ -1,0 +1,217 @@
+---
+title: "Implementing Karpathy's Autoresearch: A README-Style Guide"
+date: 2026-05-11
+readTime: 12 min read
+excerpt: A practical, opinionated walkthrough for adding an autoresearch directory to your own product : the kind that wakes up at night, checks real signals, and tells you what to fix in the morning.
+tags: [AI, AutoResearch, Claude, Experiments]
+featured: true
+---
+
+A practical, opinionated walkthrough for adding an `autoresearch/` directory to your own product : the kind that wakes up at night, checks real signals, and tells you what to fix in the morning.
+
+This is the version I wish I'd had before I built mine. It is shaped after the [karpathy/autoresearch](https://github.com/karpathy/autoresearch) pattern, but adapted for product code, not pre-training research. If you ship a website, a SaaS, an app : this is for you.
+
+## What you'll have at the end
+
+A directory inside your repo, e.g.
+
+```
+autoresearch/
+├── README.md                 # the spec (you'll read this on call 4am)
+├── run-all.js                # one orchestrator, runs everything
+├── watchdog/                 # reads real user pain from analytics
+├── bandit/                   # Thompson Sampling A/B tests
+├── lighthouse-performance/   # perf regression guard
+├── seo/                      # sitemap + IndexNow freshness
+├── i18n/                     # translation coverage
+├── keywords/                 # blog content gaps
+├── structured-data/          # JSON-LD validation
+└── performance/              # (optional) Claude-CLI overnight experiments
+```
+
+Most of these are **monitoring loops** : Node scripts that read a signal and report. One of them, `performance/`, is an **experiment loop** : Claude can edit code, run a benchmark, keep it if it's faster, revert otherwise. No LLM scoring anywhere. Score must be cheap, deterministic, and tied to real signal.
+
+## The shape of Karpathy's idea
+
+> "Any metric reasonably efficient to evaluate… with more efficient proxy metrics." : Karpathy
+
+Karpathy's setup works because LLM pre-training has an **ideal** scoring function. Validation loss is:
+
+- **cheap** : a few minutes
+- **deterministic** : same data, same result
+- **fixed-time** : 5-minute budget per experiment
+- **transferable** : score at small scale predicts large scale
+
+So you can launch dozens of experiments overnight, every score is comparable, and the agent climbs a real gradient.
+
+Your product probably has none of these. That's why naive ports of autoresearch fail. The clue is in the metric: if you can't score a candidate in 30 seconds with a script, you can't autoresearch the thing yet.
+
+## The trap (read this first)
+
+The seductive idea: "I'll have GPT-4 judge my outputs, and the agent will optimize the score."
+
+Here is what actually happens:
+
+| Karpathy's setup            | Naive product-copy port                         |
+| --------------------------- | ----------------------------------------------- |
+| Cheap, deterministic metric | GPT-4o judge : slow, $$, noisy, drifts          |
+| Fixed 5-min time budget     | Simulated conversation : variable, unstable     |
+| Score transfers to prod     | LLM judge ≠ real user behavior                  |
+| Ceiling is clear            | No ceiling; agent hill-climbs to the judge bias |
+
+The agent will get amazing scores against your judge. Your users won't notice. Your judge has biases (verbosity, formality, structure) and the agent finds them faster than humans can. You'll ship the "winner", retention will not budge, and you'll be confused.
+
+We had `composer/`, `onboarding/`, and `outreach/` loops paired with LLM judges. We removed them all. The signal was theatre.
+
+## The proxy-metric decision tree
+
+Walk this top-to-bottom every time you want a new loop. **Stop at the first "yes":**
+
+1. **Is there an analytics event that fires when this feature works?** → Read it directly. Watchdog or bandit pattern.
+2. **Is there a file-level property you can compute without an LLM?** (char count, regex, JSON-LD validates, i18n key exists) → 10 lines of Node.
+3. **Can a rule-based script compute a yes/no rubric?** (greeting includes name, turn < 12 words, message mentions creator's channel) → Rules as code. Accumulate booleans.
+4. **Can you A/B the change and read real user outcomes?** → Ship behind a flag, let bandit do Thompson Sampling. Slow but real.
+5. **Only if 1–4 all fail:** consider an LLM judge. Document why 1–4 failed. Cross-validate against ≥20 hand-labeled samples (need ≥80% agreement). Cap the score's weight so real signal has the final word.
+
+If your loop is at step 5 by default, you are about to waste two weeks. Go back to step 1.
+
+## The monitoring loop pattern
+
+A monitoring loop is a Node script that reads one signal and writes a JSON state file. That's it. No LLM. No agent. Cron-friendly.
+
+Skeleton:
+
+```js
+// autoresearch/seo/seo-monitor.js
+import fs from 'node:fs';
+
+const STATE = 'autoresearch/seo/seo-monitor-state.json';
+
+async function main() {
+	const sitemap = await fetch('https://yoursite.com/sitemap.xml').then((r) => r.text());
+	const urls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1]);
+
+	const findings = [];
+	if (urls.length < 50) findings.push({ severity: 'P1', msg: 'Sitemap looks thin' });
+
+	const prior = fs.existsSync(STATE) ? JSON.parse(fs.readFileSync(STATE, 'utf8')) : {};
+	const next = { lastRun: new Date().toISOString(), urlCount: urls.length, findings };
+
+	fs.writeFileSync(STATE, JSON.stringify(next, null, 2));
+	printDiff(prior, next);
+}
+
+main();
+```
+
+Rules I follow:
+
+- **State files are versioned.** Commit them after a run. Diff is the report.
+- **Severity tags are P0–P3.** A pager-style scale forces you to be honest about urgency.
+- **Findings include a fix hint.** "Sitemap is thin : run `npm run build:sitemap`."
+- **One signal per loop.** Two signals is two loops.
+
+## The bandit pattern (real A/B tests with no humans involved)
+
+For decisions where signal isn't a one-shot check : e.g., "which onboarding copy converts better?" : a script-based bandit handles it.
+
+Each "arm" is a hypothesis. Each session is observed by analytics. Thompson Sampling decides where to send traffic. Over time, the winner gets more share. No PM meetings, no p-value debates.
+
+```js
+const ARMS = {
+	control: { hypothesis: 'Baseline' },
+	high_challenge: { hypothesis: 'Advanced users want sparring not cheerleading' },
+	warm_support: { hypothesis: 'Low-confidence users need safety first' }
+};
+
+// Each night:
+// 1) Pull last 24h of sessions, tagged with which arm served them
+// 2) Compute success = (duration ≥ 180s) AND (messages ≥ 8)
+// 3) Update Beta(α, β) posteriors per arm
+// 4) Sample from each posterior; recommend the arm with highest sample
+// 5) Write recommendation to state file
+// 6) Emit a stability verdict
+```
+
+The verdict is the discipline:
+
+- **STABLE** : same arm recommended ≥5 nights in a row, ≥20 sessions on winner. Promotable.
+- **LEANING** : majority but not unanimous. Keep running.
+- **EXPLORING** : recommendation is flipping. Do not promote.
+
+Thompson Sampling on thin data flips daily. The stability window keeps you from celebrating noise.
+
+## The experiment loop pattern (advanced, optional)
+
+This is the one Claude actually drives. You only do this if you have:
+
+- A **deterministic local benchmark** that finishes in seconds
+- A clearly bounded set of files Claude is allowed to edit
+- The discipline to revert anything that doesn't improve the metric
+
+For example, `autoresearch/performance/`:
+
+- Benchmark = Playwright timing of "navigate to /, render hero, click CTA"
+- Allowed files: `vite.config.ts`, `svelte.config.js`, layout files
+- Loop: hypothesize → edit one file → build → benchmark → keep if faster, revert otherwise → commit
+
+Launch:
+
+```bash
+claude -p "Read autoresearch/performance/program.md and autoresearch/performance/benchmark.js.
+Create branch autoresearch/performance/$(date +%Y-%m-%d).
+Run baseline, then loop forever:
+hypothesize → edit one allowed file → build+bench → keep if score_ms drops, revert otherwise.
+Commit every kept change. NEVER STOP, NEVER ASK."
+```
+
+The metric here meets all four Karpathy criteria: cheap, deterministic, fixed-budget, and transferable. That's the only reason it works.
+
+## Stability and promotion discipline
+
+Bandit verdicts tell you what's winning. Promoting that winner to "the new default" requires three independent confirmations:
+
+| Dimension          | What to check                                                                       | Where                                       |
+| ------------------ | ----------------------------------------------------------------------------------- | ------------------------------------------- |
+| **Runtime wiring** | The winning arm is actually serving traffic. Events carry its tag.                  | Analytics : winner's `sessions_seen` rises. |
+| **Signal**         | STABLE verdict for ≥5 nights, ≥20 winner sessions, posterior win-probability ≥ 70%. | Bandit state file, history TSV.             |
+| **Docs parity**    | Experiment tracker has hypothesis, observed lift, and "promoted on {date}".         | `docs/experiment-tracker.md`.               |
+
+If any column is empty, keep running. A pretty graph alone is not a promotion.
+
+Rollback is symmetric: revert runtime, give bandit 3 nights at the old default, update docs with what went wrong. Don't delete the losing arm immediately : leave it for a week of reduced exploration. If it wins on a different cohort, that's information.
+
+## File structure as spec
+
+The folder layout *is* the contract. Each loop is a directory. Inside:
+
+```
+loop-name/
+├── program.md         # what this loop is for, in one screen
+├── state.json         # the most recent reading (versioned, diff = report)
+├── loop-script.js     # the actual code
+└── results.tsv        # history, append-only
+```
+
+`program.md` matters more than you think. It is the file Claude (or your future self) reads at 2am when something's broken. Write it like a runbook: the one signal, the threshold, the action on red.
+
+## Common failure modes
+
+- **LLM-as-judge for product copy.** It feels productive. It is hill-climbing. Delete it.
+- **Promoting on a single good night.** Bandit flips on thin data. Wait for the stability verdict.
+- **No rollback path.** If you can't revert the default in 5 minutes, you can't experiment.
+- **Adding a 10th loop before the first 3 are stable.** Loops that don't run for a week are dead code.
+- **Skipping the state-file diff.** The diff *is* the report. Read it. Or no one reads the loop.
+- **Letting Claude edit the benchmark.** The benchmark is the metric. Lock it.
+
+## Where to start (this week)
+
+You don't need ten loops. You need one that survives a week of nightly runs.
+
+1. Pick one signal you already track. (Lighthouse score. Sitemap URL count. PostHog event count.)
+2. Write a 30-line Node script. Read the signal. Write a state JSON. Commit it.
+3. Add a cron or a GitHub Action. Run it nightly.
+4. After a week, read your state diffs. Anything change? Is the change actionable?
+5. If yes : add a second loop. If no : tighten the first one, don't add more.
+
+The discipline of *reading the output every morning* is what separates autoresearch from cargo-cult automation. Build the habit before you build the system.

--- a/src/content/blog/measuring-ai-effectiveness.md
+++ b/src/content/blog/measuring-ai-effectiveness.md
@@ -1,0 +1,168 @@
+---
+title: "How to Tell If Your AI Is Actually Working"
+date: 2026-05-05
+readTime: 8 min read
+excerpt: A primer for people who've added AI to their product or workflow and have a nagging feeling they have no idea whether it's helping. A 30-minute audit you can run this afternoon.
+tags: [AI, Evaluation, Beginners]
+featured: false
+---
+
+A primer for people who've added AI to their product, workflow, or codebase : and have a nagging feeling that they have no idea whether it's helping.
+
+If that's you: it's not your fault. The AI industry has been allergic to honest measurement for two years. This post is a 30-minute audit you can do this afternoon to find out.
+
+## The honest answer is "probably not, and you should check"
+
+A pattern I see, often:
+
+> "We added Claude/GPT to our pipeline. It feels faster. The team likes it. Output looks better."
+
+Then we look at the actual numbers : cycle time, defect rate, retention, customer satisfaction, churn : and nothing has moved.
+
+This is not a story about AI being bad. The tools are real. The "feels faster" is real. But the gap between *adopting a tool* and *the tool moving a business metric* is enormous, and the only way across it is measurement.
+
+The good news: measurement is much easier than the AI-eval industry makes it sound. Most of what you need, you already have.
+
+## The three questions
+
+Before any audit, write down answers to these three. In one sentence each. Don't cheat.
+
+### 1. What changed?
+
+What's the specific thing AI is doing in your product or workflow? "We have an AI feature" is not an answer. "We added a Claude-powered support agent that handles tier-1 tickets" is.
+
+### 2. What metric should move if it's working?
+
+This is the hard one. It should be:
+
+- A number, not a feeling.
+- Tied to a real outcome, not an internal signal.
+- Measurable without a 6-week instrumentation project.
+
+For tier-1 tickets, candidates: average response time, resolution rate before escalation, customer satisfaction score, ticket reopen rate, hours of human time per week spent on tier-1.
+
+Pick **one**. If you can't pick one, the project doesn't have a defined success condition.
+
+### 3. By how much, by when?
+
+"Tier-1 ticket resolution rate up by 5 points within 30 days of launch." Specific. Falsifiable. Time-boxed.
+
+If you don't have answers to all three, you don't have an AI project. You have an AI craft project, which is fine, but please don't promise the board a number you never picked.
+
+## The five-rung ladder of measurement
+
+Roughly in order of effort. Climb only as high as you need to.
+
+### Rung 1: An event you already log
+
+Most products already emit events. If "the AI worked" maps onto an event you already track, the audit is two SQL queries away.
+
+Example: you have `purchase_completed`. You added an AI recommendation system. Did purchases per session go up?
+
+You don't need any new instrumentation. You need someone with database access and 15 minutes.
+
+### Rung 2: A regex or schema check
+
+Some AI outputs can be validated with a script. Examples:
+
+- "The model returned valid JSON" : 5 lines.
+- "The summary is under 200 words" : 3 lines.
+- "The email has a greeting and a signoff" : 10 lines.
+
+You don't need a fancy eval framework. You need a `tests/` folder and a CI step.
+
+### Rung 3: A rule-based rubric
+
+When "did it work" is more than one boolean, write the rubric down. Literally a checklist:
+
+- Mentions the user by name
+- Includes the order number
+- Avoids the phrase "I'm sorry for the inconvenience"
+- Resolves the question in ≤3 sentences
+
+Each item is a boolean. Sum them. That sum is your score. It's deterministic. It's debuggable.
+
+### Rung 4: A live A/B test
+
+When the output quality really does need a human to assess, run two versions in front of real humans. Look at downstream behavior:
+
+- Did they reply?
+- Did they buy?
+- Did they come back?
+- Did they rate?
+
+A/B testing is slow and you need volume, but the signal is real. A bandit can shift traffic toward the winner automatically over a few weeks.
+
+### Rung 5: An LLM-as-judge eval
+
+This is the rung the industry is obsessed with. It's the *last* one to try, not the first.
+
+If you reach this rung, the rules are:
+
+- Cross-validate the judge against ≥20 hand-labeled examples. Need ≥80% agreement.
+- Cap the judge's weight if you also have real-user signal.
+- Re-validate every model version bump.
+
+If you find yourself building at rung 5 without first checking rungs 1–4, stop and check.
+
+## The 30-minute audit
+
+For each AI feature, integration, or workflow you have:
+
+### Minute 0–5: name it
+
+Write the one-sentence description. "Claude reviews PRs and writes a summary." "GPT-4 suggests product titles." Each one gets its own row in your audit doc.
+
+### Minute 5–10: the metric question
+
+For each row, write the single metric that should move if it's working. If you can't pick one in 5 minutes, write "❓" and move on. (Spoiler: those rows are usually the problems.)
+
+### Minute 10–20: pull the number
+
+For the rows with a clear metric, get the actual value. Compare it to the value before the AI was added.
+
+Three categories of result:
+
+- **Moved up clearly.** Keep it. Document the lift. Defend it next time someone proposes ripping it out.
+- **Flat.** Have a hard conversation. Is the AI doing nothing? Is the metric wrong? Set a checkpoint 30 days out.
+- **Moved down.** Roll it back today.
+
+### Minute 20–30: kill list
+
+What is the audit telling you to stop doing?
+
+- Rows you couldn't even define a metric for : these are vibes, not features.
+- Rows where the metric is flat after a fair window : ROI is zero.
+- Rows where you find yourself wanting to argue with the number : that's the most important one. Argument means you don't trust the metric you picked. Fix the metric, not the AI.
+
+Most teams discover that 20–30% of their AI work is producing measurable value, 50% is neutral, and 20% is actively backward.
+
+## The signs you have an eval problem (not an AI problem)
+
+- **The team can't agree on whether the AI is working.** You don't have a metric, you have a debate.
+- **Every demo looks great but the dashboards never change.** Cherry-picking is the default state of un-measured AI.
+- **The "score" is going up but business outcomes aren't.** Classic LLM-judge hill climb.
+- **You're afraid to look at the number.** That fear is information. Look at the number.
+
+## Working with humans on this
+
+People feel ownership over the AI tools they introduced. If your audit suggests something should be turned off, that's a social problem more than a technical one. Moves that help:
+
+- **Audit the *whole portfolio* at once, not just someone's pet.** Looking at everything makes the conversation about the framework, not the person.
+- **Have the metric picked *before* you check the number.** "We agreed we'd judge this on resolution rate. Resolution rate didn't move." That's a much better conversation than "I went looking and found it's bad."
+- **Make rollback cheap.** If turning off the AI feature is a 6-week project, no one will do it. If it's a flag flip, people will.
+- **Celebrate the kills.** A team that publicly retires a useless AI feature is healthier than one that quietly leaves it on.
+
+## What "good measurement" looks like
+
+The aspiration is not "we have a sophisticated eval framework." It's:
+
+> Every AI thing we ship has one number it should move. We check the number on a known cadence. When the number doesn't move, we either fix the metric or kill the feature.
+
+That's it. No platform, no vendor, no offsite. Just the discipline of asking *what should move* and then *looking*.
+
+## One-line takeaway
+
+> Pick a metric, check the number, and be willing to kill the feature if the number doesn't move. The rest is decoration.
+
+Measurement isn't a special AI skill. It's just engineering judgment applied to a hyped technology. You already have the skill. Use it on this.

--- a/src/content/blog/modern-css-techniques.md
+++ b/src/content/blog/modern-css-techniques.md
@@ -1,0 +1,112 @@
+---
+title: Modern CSS Techniques Every Developer Should Know
+date: 2023-12-20
+readTime: 7 min read
+excerpt: From CSS Grid and Flexbox to custom properties and container queries, explore the modern CSS features that make building responsive layouts easier than ever.
+tags: [CSS, Frontend, Design]
+featured: false
+---
+
+CSS has quietly become one of the most powerful tools in a frontend developer's kit. The features that shipped over the last few years removed entire categories of hacks. Here are the ones worth learning first.
+
+## CSS Custom Properties
+
+Variables in CSS. The bedrock of any modern design system.
+
+```css
+:root {
+	--accent: #5b8bff;
+	--radius-md: 0.5rem;
+}
+
+.button {
+	background: var(--accent);
+	border-radius: var(--radius-md);
+}
+```
+
+The magic is that they cascade and respond to media queries. You can swap an entire theme by re-declaring a handful of properties under a `[data-theme="dark"]` selector.
+
+## Container Queries
+
+Media queries respond to the viewport. Container queries respond to the *element*. That difference is enormous for any component that gets reused at different sizes.
+
+```css
+.card-container {
+	container-type: inline-size;
+}
+
+@container (min-width: 400px) {
+	.card {
+		grid-template-columns: 1fr 2fr;
+	}
+}
+```
+
+A card next to a wide sidebar can lay out one way; the same card in a narrow column lays out another. Components become genuinely portable.
+
+## CSS Grid for Layout
+
+Flexbox is for arranging items along an axis. Grid is for arranging items in two dimensions. Most layouts that used to need nested flex containers collapse into a single grid declaration.
+
+```css
+.layout {
+	display: grid;
+	grid-template-columns: 240px 1fr;
+	grid-template-rows: auto 1fr auto;
+	min-height: 100vh;
+}
+```
+
+Pair it with `grid-template-areas` for layouts that read like ASCII art.
+
+## :has() : The Parent Selector
+
+Possibly the most-requested CSS feature ever. Style a parent based on its children:
+
+```css
+.card:has(img) {
+	padding-top: 0;
+}
+
+form:has(input:invalid) button[type="submit"] {
+	opacity: 0.5;
+}
+```
+
+This deletes an enormous category of "add a class with JavaScript" patterns.
+
+## Logical Properties
+
+Instead of `margin-left`, write `margin-inline-start`. Instead of `padding-top`, write `padding-block-start`. The result: layouts that mirror automatically for right-to-left languages without a separate stylesheet.
+
+```css
+.card {
+	padding-inline: 1rem;
+	margin-block: 2rem;
+}
+```
+
+## Color Functions
+
+`color-mix()` lets you blend colors in any color space, finally giving us the "tint by 10%" operation that designers actually want.
+
+```css
+.button:hover {
+	background: color-mix(in srgb, var(--accent), white 15%);
+}
+```
+
+## Aspect Ratio
+
+Locking aspect ratio without padding-hacks:
+
+```css
+.video-thumbnail {
+	aspect-ratio: 16 / 9;
+}
+```
+
+## Conclusion
+
+The CSS of 2024 is closer to a real layout system than the CSS of 2014. Most "I need a JavaScript library for this" needs are now native one-liners. Re-learn the language : it's much better than you remember.

--- a/src/content/blog/promotion-checklist-for-experiments.md
+++ b/src/content/blog/promotion-checklist-for-experiments.md
@@ -1,0 +1,116 @@
+---
+title: "The Promotion Checklist: Shipping an Experiment Win Without Faking It"
+date: 2026-04-25
+readTime: 6 min read
+excerpt: A bandit recommending "winner" is not a winner. Three independent dimensions you should check before you flip the default. Borrowed from Shisa's definition-of-done framing.
+tags: [AI, Experiments, Process]
+featured: false
+---
+
+The bandit says arm B has been winning for five nights straight. The posterior probability of "best" is 78%. The chart is monotonically up and to the right.
+
+Do you ship it?
+
+Most teams do, here. Most teams shouldn't. A pretty chart and a stability verdict are *necessary* to promote an experiment win, but they are not *sufficient*. A single missing dimension is enough to ship a regression and not notice for a month.
+
+This is the checklist I run before flipping any default. Three dimensions. All three required. Borrowed from Shisa's definition-of-done framing.
+
+## Why three dimensions
+
+A bandit answers one question: *given my success criterion, which arm has the best posterior?*
+
+That's a great answer to one question. It is not an answer to:
+
+- "Is this arm actually being served to users?" (You'd be surprised how often promotion happens before traffic.)
+- "Did we write down the hypothesis we're now claiming was correct?" (If you didn't, you can rationalize anything as a win.)
+- "Is the success criterion still measuring what we care about?" (Goals drift. Metrics don't notice.)
+
+Each dimension catches a different failure mode. Skip one, and the failure mode it would have caught is the one you'll have.
+
+## Dimension 1: Runtime wiring
+
+The winning arm has to actually be serving traffic, end-to-end, with events tagged correctly.
+
+**Check:**
+
+- Open analytics. Filter to the last 24h. Group `conversation_ended` (or whatever your terminal event is) by `prompt_variant` or whatever arm-tag field you use.
+- The winning arm's session count should be visibly larger than the others. If all arms are roughly equal, your runtime is still in exploration mode, not exploitation.
+- Click into a few sessions from the winner. Verify the events carry the correct tag.
+- Look at the *composer* / *runtime* source for the arm. Does the parameter combination you defined in `ARMS` actually get rendered? Or is the composer ignoring one of the fields and silently falling back to defaults?
+
+The last one is sneakier than it sounds. If your "high_challenge" arm is defined as `{ correctionStyle: 'inline', challenge: 'high', ... }` but the composer only honors `correctionStyle`, then "high_challenge" is identical to "control" in production, and any difference in metrics is pure noise.
+
+**Failure mode this catches:** declaring a winner that was never actually different from the loser.
+
+## Dimension 2: Signal
+
+This is the dimension most teams remember. It's still worth being explicit about what "signal" actually means.
+
+**Check:**
+
+- The bandit's stability verdict is STABLE (not LEANING, not EXPLORING).
+- The winning arm has ≥ N sessions, where N is high enough that you'd defend it to a stranger. Twenty is a common floor.
+- The posterior probability of "best" is ≥ 70%.
+- The success criterion is still the same one you defined when the experiment started. (If you redefined success mid-experiment, the experiment is invalid.)
+
+**Failure mode this catches:** celebrating a one-night spike. Posteriors on thin data are wide; sampling can pick any arm. The stability window is the discipline that says "wait until the chart bores you."
+
+The 70% number is a judgment call. The point isn't the exact threshold : the point is to write down a threshold *before* you check the number, and then honor it.
+
+## Dimension 3: Docs parity
+
+This is the dimension everyone skips. It's the most important.
+
+**Check:**
+
+- Open the experiment tracker. Find the row where you originally logged this experiment.
+- Does it have: hypothesis (one sentence), success criterion (one sentence), start date, the arm names, the expected lift?
+- Update the row: "promoted on {date}, observed lift = X% on metric Y."
+
+If the original row is missing : because you started the bandit "informally" and never wrote it down : the experiment is unfinished. Don't promote until the row exists and is filled in.
+
+Why does this matter? Three reasons:
+
+1. **You can't be wrong if you didn't write down what you predicted.** Without a recorded hypothesis, every result is a "win," because you can always invent a story that fits.
+2. **Future-you debugs the system using the tracker.** Six months from now, when retention dips and you're trying to find which experiments could be the cause, the tracker is the only document that maps "what changed when."
+3. **Teams that write down hypotheses get better at making them.** The act of writing "I predict variant B will lift conversion by 8% because users prefer concrete value props" makes you face whether you actually believe it. Predictions that turn out wrong are the most useful predictions you'll ever make.
+
+**Failure mode this catches:** experiments that drift into vibes-based decisions. If you can't articulate what would have falsified the win, the win is a story, not a finding.
+
+## What it looks like all together
+
+A real promotion, in the order it happens:
+
+1. **Bandit says STABLE.** 5 nights consecutive, arm B winning. Posterior P(best) = 82%. Sessions on winner = 47.
+2. **Runtime check.** Pull analytics: arm B is serving 60% of traffic now (bandit ramped it up). Events carry `prompt_variant: B`. Composer source shows all four arm parameters are rendered. Three sample sessions look right.
+3. **Tracker check.** Row exists. Hypothesis: "B's tighter prompt will produce shorter, higher-quality completions, lifting `task_completed` by 5%+." Success criterion: "`task_completed` rate per session." Observed lift: 7.4%. Add "promoted on 2026-04-25, observed lift = 7.4%."
+4. **Flip the default.** Composer config: `default_variant = 'B'`. Deploy.
+5. **Verify post-deploy.** Next batch of events: all carry `prompt_variant: B` as the new floor. (Bandit will still nudge traffic to other arms for exploration; that's fine.)
+
+Total elapsed: about an hour. Total decisions: one. But all the supporting checks are visible, in writing, and replayable.
+
+## What promotion is *not*
+
+A few common false-promotions to watch for:
+
+- **"It looks better."** This is not a checklist item. If you can't point at a number, you're not promoting, you're rebranding.
+- **"The team likes it."** Same.
+- **"The stability verdict is STABLE so we're done."** No : you've cleared one dimension. Two to go.
+- **"We'll write the tracker entry later."** No, you won't.
+- **"It's only one parameter change, do we really need all this?"** Yes. Because the next one is "only one parameter change" too. And the one after. The checklist is what prevents a year of "only one parameter changes" from compounding into an unauditable mess.
+
+## The healthy team test
+
+You can tell whether a team has a real promotion discipline by asking one question:
+
+> "When was the last time the bandit said STABLE and you didn't promote?"
+
+If the answer is "never," the checklist is a rubber stamp. The whole point of the three dimensions is that some experiments should fail the check. Maybe runtime wiring isn't right yet. Maybe the tracker entry doesn't exist. Maybe the success criterion drifted.
+
+A team that has *declined to promote* a stable winner, at least once in the last quarter, has a real process. A team that has never declined doesn't.
+
+## The one-line takeaway
+
+> STABLE is necessary. STABLE plus runtime plus docs is sufficient. Don't promote on any one alone.
+
+Most experiment regressions come from skipping a dimension. The checklist is fifteen minutes. It is the cheapest insurance you'll ever buy on your product.

--- a/src/content/blog/rollback-discipline-for-experiments.md
+++ b/src/content/blog/rollback-discipline-for-experiments.md
@@ -1,0 +1,122 @@
+---
+title: "Rollback Discipline: When Your Shipped Winner Stops Winning"
+date: 2026-04-28
+readTime: 6 min read
+excerpt: A symmetric rollback protocol for experiments that turned out to regress. Three dimensions, one week of patience, and one rule you'll be tempted to break.
+tags: [AI, Experiments, Process]
+featured: false
+---
+
+Every team that runs A/B tests eventually ships a "winner" that wasn't. The bandit recommended it, the dashboard agreed, you promoted it to default, and three weeks later retention is down, support tickets are up, and someone is asking the obvious question: was this the change?
+
+Yes. Roll it back. That's the easy part. The hard part is the *discipline* of how you roll back, because the wrong reflex turns a recovery into another mistake.
+
+This is the protocol. It mirrors the promotion checklist, deliberately.
+
+## The wrong reflex
+
+When you suspect a regression, the temptation is to:
+
+1. Flip the default back, immediately.
+2. Delete the bad arm from the bandit so it stops being explored.
+3. Find someone to blame, or yourself to blame.
+4. Forget about it once the dashboard recovers.
+
+All four are wrong, in subtle ways. Let's walk through what to do instead.
+
+## The three-dimensional rollback
+
+A promotion required three confirmations: runtime wiring, signal, and docs parity. A rollback restores all three.
+
+### 1. Runtime: flip the default back, today
+
+Yes, immediately. Don't wait. The point of a feature flag is that this is a one-line operation.
+
+Two things to verify after the flip:
+
+- **The flip actually deployed.** Look at the next batch of events. Are they carrying the previous arm's tag? If yes, you're back. If no, the flag wasn't wired right, and you have a worse problem than a regression.
+- **The blast radius.** Was anything else changed alongside the original promotion? A composer parameter, an env var, a different default elsewhere? Find them all. Flip them all.
+
+### 2. Signal: give the rollback three nights before you celebrate
+
+You're not done when the flag is flipped. You're done when the metric recovers, and a recovery takes time. The bandit needs to see new data under the reverted default. New users need to flow through.
+
+Three nights, minimum:
+
+- Night 1: traffic shifts back to the old default. Watchdog and bandit start seeing it.
+- Night 2: enough data to see whether the regressing metric is starting to recover.
+- Night 3: enough data to be confident the recovery isn't a one-night fluke.
+
+In those three nights, *do not change anything else*. Resist the urge to "also try a fix." If you change two variables at once, the regression analysis becomes uninterpretable. One variable. Three nights.
+
+### 3. Docs: write the why down, in detail
+
+Open the experiment tracker. Find the row where you logged "promoted on {date}." Add a "Rolled back on {date}" row.
+
+In the description:
+
+- **What regression you saw.** With numbers.
+- **Why the stability verdict missed it.** This is the most valuable line you'll write all month. What signal *should* have caught this and didn't? Was your success criterion too narrow? Was the cohort that suffered too small to move the aggregate? Did the bandit promote on a weekday-only spike?
+- **What guardrail you're adding for next time.** "We'll also gate promotion on watchdog P1 count staying flat." "We'll require ≥5% of stable sessions to come from {cohort X}."
+
+That third bullet is the actual deliverable of the rollback. The regression is information. Don't waste it by just reverting and moving on.
+
+## The rule you'll be tempted to break
+
+When you roll back, do *not* delete the bad arm from the bandit immediately.
+
+Leave it. Let it run at reduced weight for at least a week.
+
+The reason: if the bad arm wins again, on a different cohort, in a different week, that's signal worth investigating. Maybe the arm is actually good for power users and bad for new ones. Maybe it works on mobile and fails on desktop. Maybe it's seasonal.
+
+Deleting the arm closes off all of that information. You'll never know.
+
+Yes, it feels good to delete the bad arm. Don't. Let it sit in the corner for a week. Then decide.
+
+## A short worked example
+
+The hypothetical: you promoted `socratic` (an arm that uses Socratic questioning in onboarding) to default. Two weeks in, retention drops 3 points and support tickets mention "the bot doesn't help me get started."
+
+**Day 0** (you notice):  
+Flip default back to `control` in the composer. Verify new sessions carry `prompt_variant: control`.
+
+**Day 1–3:**  
+Bandit and watchdog see new sessions. Day 1 retention metric still includes the bad cohort's tail; don't read into it. Day 2: starting to recover. Day 3: recovery is clear.
+
+**Day 4:**  
+Open experiment tracker. New row:
+
+> Rolled back `socratic` on {date}. Observed -3pt retention and +18% "doesn't help me get started" tickets over the 14 days after promotion. Bandit STABLE verdict missed it because: success criterion was "session duration ≥ 180s," which the Socratic style actually improves (users spend more time confused). Adding new guardrail: promotion gated on `tutorial_completed` rate, not just session duration. The arm itself remains in the bandit at reduced weight for one week to see if it wins on advanced-user cohort.
+
+**Day 11:**  
+Review the `socratic` arm's performance over the week. If it's winning only on a specific cohort, fork the bandit per-cohort. If it's losing across the board, retire it now.
+
+Notice: the rollback itself took five minutes. The discipline around it took eleven days. That's normal. The five-minute part is the cheap part.
+
+## The blame question
+
+Who picked the bad arm? Whose fault is this?
+
+This is almost never the right question. The bandit recommended it. The stability check passed. The promotion checklist was followed. The signal turned out to be misleading. Calling that "someone's fault" is a misread of how the system works.
+
+The right question is: **what's our next guardrail?**
+
+The guardrail isn't a person. It's a check. Every rollback should ship one new check. Over the years, your promotion process gets more checks, fewer regressions, and the team gets less defensive : because the system gets better, not because people stop making mistakes.
+
+If you find yourself in a meeting where the topic is "who's to blame," gently redirect: "What's the guardrail we're adding?"
+
+## The healthy team pattern
+
+Teams that handle rollbacks well share three habits:
+
+1. **Public rollback notes.** The "what went wrong, what's the new guardrail" gets shared. Not in a recriminatory way : as institutional learning.
+2. **Time-boxed waiting.** Three nights, not three weeks. Patience is a discipline, but so is closure. Stretching the rollback window indefinitely is its own dysfunction.
+3. **No silent reverts.** Every rollback is logged. Even if it was painful. The experiments you *secretly* rolled back are the ones you'll repeat the mistake on.
+
+If your team currently silently reverts experiments and never writes anything down, the cheapest thing you can do this week is start a one-table doc called "Experiments rolled back" and back-fill it for the last six months. The shape of that table tells you a lot about your decision quality.
+
+## The takeaway
+
+Rollback is not failure. It's the second half of the experiment. Promotion is "we believed this," rollback is "we believed wrong, here's what we learned." Both rows belong in the tracker. Both are healthy. The unhealthy version is a tracker with only promotions.
+
+A good experiment process has roughly as many "rolled back" entries as "still default" entries. If you only have promotions in your history, you're not running enough experiments, or you're not looking honestly enough at the results.

--- a/src/content/blog/the-power-of-typescript.md
+++ b/src/content/blog/the-power-of-typescript.md
@@ -1,0 +1,47 @@
+---
+title: The Power of TypeScript in Large-Scale Applications
+date: 2024-01-01
+readTime: 5 min read
+excerpt: Why TypeScript is essential for building maintainable applications and how to get the most out of it. Discover tips for better type safety and developer experience.
+tags: [TypeScript, JavaScript]
+featured: false
+---
+
+TypeScript has become the de facto standard for large-scale JavaScript applications. But why? Let's explore what makes TypeScript so powerful.
+
+## Catch Errors Early
+
+TypeScript catches errors at compile time, not runtime:
+
+```ts
+function greet(name: string) {
+	return `Hello, ${name}!`;
+}
+
+greet(123); // Error: Argument of type 'number' is not assignable
+```
+
+## Better IDE Support
+
+With types, your IDE can provide intelligent autocomplete, refactoring tools, and inline documentation. This dramatically improves developer productivity.
+
+## Self-Documenting Code
+
+Types serve as documentation that's always up-to-date:
+
+```ts
+interface User {
+	id: string;
+	name: string;
+	email: string;
+	role: 'admin' | 'user';
+}
+```
+
+## Refactoring with Confidence
+
+TypeScript makes refactoring safer. When you change a type, the compiler tells you everywhere that needs to be updated.
+
+## Conclusion
+
+TypeScript's type system provides a safety net that becomes increasingly valuable as your application grows. The upfront investment in types pays dividends in fewer bugs and easier maintenance.

--- a/src/content/blog/the-program-md-pattern.md
+++ b/src/content/blog/the-program-md-pattern.md
@@ -1,0 +1,181 @@
+---
+title: "The program.md Pattern: How to Brief an AI Like a Runbook"
+date: 2026-05-01
+readTime: 6 min read
+excerpt: One file per AI task, structured like an oncall runbook. Goal, allowed files, forbidden files, loop, stopping criteria. This is what separates AI experiments that compound from AI experiments that drift.
+tags: [AI, Claude, Writing]
+featured: false
+---
+
+Most AI workflows die not because the model is bad, but because no one wrote down what the model was supposed to do. After the third "I asked it to refactor X but it ended up rewriting Y" incident, you start to suspect the problem isn't the AI.
+
+The fix is borrowed from infrastructure: write a runbook. Not for humans, for the model. One per task. Keep it short. Keep it explicit. The convention I use is to name it `program.md` and put it next to the code it governs.
+
+This post is the shape of that file, the reasons each section exists, and why this single change shifts AI work from chaos to compounding.
+
+## Why "program," not "prompt"
+
+A prompt is what you type when you want one thing. A program is what you write when you want the *same* thing, reliably, over time, by something that doesn't have memory.
+
+`program.md` is the file the model reads at the start of every iteration. If you change the file, the program changes. If you don't, every run is the same run. That property : *idempotent re-runnability* : is what makes AI work compound instead of drift.
+
+## The minimum viable program.md
+
+```markdown
+# {Name of the task in one line}
+
+## Goal
+{Two sentences. What's the desired state at the end? What's the *measurable*?}
+
+## Allowed files
+- {explicit path}
+- {explicit path}
+
+## Forbidden
+- {explicit path}
+- {explicit path}
+
+## Loop
+1. {first step, observable}
+2. {second step, observable}
+3. ...
+
+## Stopping criteria
+{When does this end? Or: "Never stop, never ask."}
+```
+
+That's it. Five sections. No prose. Read it in 30 seconds. Implement it in five minutes.
+
+## Section-by-section, with the reasoning
+
+### Name (one line)
+
+Not the task description. The *name*. "Performance experiment loop." "Daily SEO monitor." "Translation key coverage check."
+
+A file that doesn't have a short name doesn't have a clear scope. If you can't name it, you don't yet know what it does.
+
+### Goal (two sentences)
+
+Sentence 1: what state of the world should exist at the end of a run?  
+Sentence 2: what *number* measures whether sentence 1 happened?
+
+```markdown
+## Goal
+Reduce the time-to-interactive on / for desktop. Measured by `benchmark.js`, lower is better.
+```
+
+If the goal doesn't have a measurable, you can't loop on it. You can chat about it, sure. But you can't put a model in an unsupervised loop with a vague goal and expect anything but drift.
+
+### Allowed files
+
+Explicit paths. Not glob patterns.
+
+```markdown
+## Allowed files
+- vite.config.ts
+- svelte.config.js
+- src/routes/+layout.svelte
+```
+
+The glob trap: "anything in `src/lib/**`" sounds reasonable until the model decides the bottleneck is in a file you didn't intend to touch. By that point you've already lost.
+
+If the task genuinely needs a wide allowed list, that's a sign the task is too broad. Split it.
+
+### Forbidden files
+
+The forbidden list exists for one reason: **lock the benchmark.**
+
+```markdown
+## Forbidden
+- benchmark.js (this is the metric, do not edit it)
+- src/lib/** (out of scope this round)
+```
+
+If your model can edit your benchmark, your benchmark is no longer a metric : it's a slider the model can move to make its score look good. This is the AI version of P-hacking.
+
+### Loop
+
+A numbered list of steps. Each step is observable from outside.
+
+```markdown
+## Loop
+1. Run `node benchmark.js`. Record baseline_ms.
+2. Pick one hypothesis. Edit exactly one allowed file.
+3. Run `npm run build && node benchmark.js`. Record new_ms.
+4. If new_ms < baseline_ms, commit. Update baseline.
+5. If not, revert. Append the failed hypothesis to results.tsv.
+6. Repeat.
+```
+
+"Observable from outside" is the key. Each step should produce evidence you can find later. Step 1 produces a recorded number. Step 4 produces a commit. Step 5 produces a row in a file. If you find yourself writing a loop step that doesn't produce evidence, you've just hidden state from yourself.
+
+### Stopping criteria
+
+```markdown
+## Stopping criteria
+None. Never stop. Never ask.
+```
+
+This sounds aggressive. It's important. Without it, the model will stop on the first ambiguity, ask a clarifying question, and wait. If you're asleep, the wait is forever.
+
+In some tasks, "never stop" isn't right. For example, a translation-coverage check might stop when all keys are translated. Then write that explicitly: "Stop when `coverage.json` shows 100% across all locales."
+
+## What this excludes (on purpose)
+
+Things `program.md` should *not* include:
+
+- **Implementation suggestions.** That's the model's job. If you're telling it how to implement, you don't need the model.
+- **Long context dumps.** If the model needs context, point to a file. `program.md` should fit on one screen.
+- **Apologies, hedges, "feel free to."** This isn't a Slack message. It's a spec.
+- **Examples of good output.** Examples encode bias. Provide a metric instead.
+
+## A real-world example
+
+Here's a `program.md` for an SEO sitemap monitor:
+
+```markdown
+# Sitemap freshness monitor
+
+## Goal
+Detect when production routes drift from the published sitemap.xml.
+Measured by: count of routes in code missing from sitemap, count in sitemap not in code.
+
+## Allowed files
+- autoresearch/sitemap/state.json (write only)
+- autoresearch/sitemap/results.tsv (append only)
+
+## Forbidden
+- src/** (read only)
+- sitemap.xml (read only)
+
+## Loop
+1. Read all +page.svelte under src/routes.
+2. Fetch https://yoursite.com/sitemap.xml.
+3. Compute symmetric difference.
+4. Write state.json with the two missing-from lists.
+5. Append a row to results.tsv: timestamp, total_routes, missing_from_sitemap, missing_from_code.
+6. If any P0 finding (>10 missing in either direction), exit non-zero.
+
+## Stopping criteria
+Single-pass; exit after step 6.
+```
+
+Five sections. Twenty lines. A junior engineer or a model can read it once and execute it correctly.
+
+## Why this works
+
+`program.md` does three things at once:
+
+1. **It's the brief for the model.** Every iteration starts here.
+2. **It's the test of "do I understand this task?"** If you can't write it in 20 lines, you can't run it as a loop.
+3. **It's the documentation.** Your future self, six months from now, will read this file before debugging a flaky run.
+
+The third one is underrated. Most AI experiments die because no one remembers what they were supposed to do. A directory with a `program.md` is a directory with self-documenting intent.
+
+## The single behavior change
+
+If you take nothing else from this post: **don't run an unsupervised AI task without writing the `program.md` first.**
+
+The temptation is to "just try a prompt and see what happens." Sometimes that's the right move : exploratory chat is a perfectly fine mode. But the second you start running a thing on a loop, in a cron, overnight : write the file. The 5 minutes you spend writing it save 5 hours of "why did it do that?"
+
+The pattern works for human collaborators too, by the way. The same five sections work for an intern's project brief. That's not a coincidence.

--- a/src/content/blog/the-proxy-metric-trap.md
+++ b/src/content/blog/the-proxy-metric-trap.md
@@ -1,0 +1,122 @@
+---
+title: "The Proxy-Metric Trap: Why Your LLM Eval Loop Is Probably Lying"
+date: 2026-05-09
+readTime: 6 min read
+excerpt: A short, hard-earned post about the single most expensive mistake I see teams make with AI : letting another LLM judge the work. If you have a score function that's a prompt, this is for you.
+tags: [AI, Evaluation, Experiments]
+featured: true
+---
+
+A short, hard-earned post about the single most expensive mistake I see teams make with AI: letting another LLM judge the work.
+
+If you have a "score function" anywhere in your stack and that score function is a prompt, this post is for you.
+
+## The shape of the trap
+
+The pitch is irresistible. You want to optimize *something soft*: a welcome message, an onboarding flow, an outreach email, a tone of voice. You can't measure it with a regex. You don't have enough users yet to A/B it. So you do the obvious thing:
+
+> "I'll just have GPT-4 score the outputs and let the agent optimize."
+
+The first time you run it, the scores go up. The outputs look great. You ship.
+
+A month later: retention is flat, conversion is flat, the metric you actually care about has not moved a millimetre. What happened?
+
+Your agent learned the judge's bias faster than it learned your users.
+
+## Why this happens, in one paragraph
+
+LLM judges are not measuring quality. They are measuring **distance to whatever pattern the judge prefers**. That pattern includes: verbosity, structure, hedging, helpful-assistant tone, certain rhetorical moves. None of these are the same as "this works for the person reading it." When you put an agent in a loop with such a judge, the agent finds the bias faster than a human ever could and climbs it. The score goes up. The product gets worse, or stays the same, dressed up in a more LLM-shaped costume.
+
+This is not theoretical. We ran loops like this. They produced gorgeous "winners" that did not improve a single real metric. We deleted them.
+
+## What a good metric actually looks like
+
+Karpathy's autoresearch works because pre-training has the perfect scoring function: validation loss. It is:
+
+- **cheap** : seconds to compute
+- **deterministic** : same input, same output
+- **fixed-time** : 5-minute budget per experiment
+- **transferable** : the score at small scale predicts the score at large scale
+
+Your candidate metric should pass all four tests. If your "score" is "ask GPT-4 to rate this from 1-10," it fails on **deterministic** (judges drift run to run, model to model), it fails on **fixed-time** (you pay per call), and it fails hard on **transferable** (a high LLM-score does not predict user behavior).
+
+If three of the four are missing, you are not measuring. You are LARPing measurement.
+
+## The four-step ladder before you reach for an LLM judge
+
+This is the checklist I run every time someone proposes a new "scored loop":
+
+### 1. Is there an event you already log when this works?
+
+If your funnel has `signup_completed`, `first_message_sent`, `tutorial_finished`, `purchase_succeeded` : that is the metric. Don't build a fancy judge to predict the event. **Read the event.**
+
+Cost: 30 lines of Node and an API key.
+
+### 2. Can a regex or schema-validator tell you yes/no?
+
+"The generated JSON parses." "The email subject is under 60 chars." "The greeting includes the user's first name." "JSON-LD validates against schema.org."
+
+These are tiny scripts. They give you a real boolean. The agent cannot hill-climb a regex without actually fixing the thing.
+
+Cost: 10 lines of Node.
+
+### 3. Can a rule-based rubric produce a yes/no score?
+
+Break "quality" into checklist items:
+
+- Mentions creator's channel? (boolean)
+- Asks one question, not three? (boolean)
+- Stays under 12 words? (boolean)
+- Avoids the phrase "as an AI"? (boolean)
+
+Sum the booleans. That is a rubric score. It's still cheap. It's still deterministic. And critically, it's debuggable : when a score is wrong, you can point at the rule.
+
+Cost: 50–200 lines of Node.
+
+### 4. Can you A/B it with real users?
+
+Even slow A/B is better than fast LLM-judging. Put two variants behind a flag. Send users to them. Read the outcome event. Let a bandit decide who wins.
+
+Cost: a feature flag, a week, and patience.
+
+### 5. (Only if 1–4 fail) Maybe an LLM judge
+
+When you genuinely cannot get signal any other way, and the alternative is shipping blind, an LLM judge can play a small role. The rules:
+
+- Document why steps 1–4 failed. In writing. To yourself.
+- Hand-label ≥20 samples. Cross-check the judge against your labels. You want **≥80% agreement**. If you get less, fix the prompt or kill the judge.
+- Cap the score's weight. If you also have real-user data, the real data has the final word.
+- Re-validate the judge every model version bump. They drift.
+
+If the judge is the *only* score in your loop : stop. Go back to step 1.
+
+## The "but I have to optimize copy" objection
+
+A common pushback: "I'm optimizing chat copy / outreach tone / marketing language. There is no clean metric."
+
+Yes there is. It's just slow.
+
+- Ship the change behind a flag.
+- Tag the sessions with which variant they saw.
+- Look at the downstream event you care about (replies, conversion, retention).
+- Let a bandit do Thompson Sampling and shift traffic over weeks.
+
+This is slower than a 5-minute LLM-judge loop. It is also the only way you find out if the change actually works. The autoresearch loops worth running are the slow honest ones, not the fast theatrical ones.
+
+## A 15-minute audit you can run right now
+
+Open the spreadsheet or scratchpad where you track "AI experiments." For each one:
+
+1. **What's the score function?** Write it in one sentence. If you can't, the loop is unfalsifiable. Pause it.
+2. **Is the score cheap, deterministic, and tied to real signal?** If no on any of those three : the loop is producing theatre. Mark it red.
+3. **If you removed the loop tomorrow, would you lose any decision-quality?** If you'd lose nothing : it's dead weight. Kill it.
+
+Most teams that do this discover half their "AI experimentation infrastructure" is theatre. The remaining half is where all the value is.
+
+## The one-line takeaway
+
+> If your score function is itself an LLM, you are not measuring : you are predicting an LLM's preferences. Make sure that's what you actually want before you put an agent in a loop with it.
+
+The cheapest loops in autoresearch are also the most valuable: a regex, an event count, a Lighthouse score, a sitemap diff. The fancy LLM-judged loops feel like progress. They are usually drift.
+
+Optimize for measurable. The rest is vibes.

--- a/src/content/blog/thompson-sampling-without-stats-degree.md
+++ b/src/content/blog/thompson-sampling-without-stats-degree.md
@@ -1,0 +1,173 @@
+---
+title: "Thompson Sampling Without a Stats Degree"
+date: 2026-05-03
+readTime: 7 min read
+excerpt: A working developer's intro to multi-armed bandits for product A/B tests. Includes the 30-line Node implementation, why it beats classical A/B in most real situations, and the failure modes nobody warns you about.
+tags: [AI, Experiments, Tutorial]
+featured: false
+---
+
+You have three versions of an onboarding flow. You'd like to know which converts best. Classical advice: "Run an A/B test, gather n users, compute p-values, declare a winner." Reality: by the time you've gathered n users, your three flows have been three meetings and someone already shipped a fourth.
+
+There is a better default for product teams: **Thompson Sampling**. It's a multi-armed bandit algorithm that decides where to send traffic *as data comes in*, so the winning variant gets more share as the experiment runs. No p-values. No fixed sample size. Thirty lines of code.
+
+This post is what I wish someone had given me before I wrote my first bandit.
+
+## The intuition
+
+Imagine three slot machines. You don't know the payout rate of any of them. You can either:
+
+- **Pure exploration.** Pull each machine equally often forever. Maximises information, minimises money.
+- **Pure exploitation.** Find the best one early and only pull that. Maximises short-term winnings, but if you got unlucky on the first few pulls of the *actually-best* machine, you'll miss it forever.
+
+Thompson Sampling is the elegant middle: it pulls each machine with probability proportional to *its belief that this machine is the best*. As you accumulate data, belief sharpens. The best machine gets pulled more. The worst, less. The exploration/exploitation trade-off resolves itself.
+
+For "machines," read: variants of your onboarding copy, your prompt, your CTA button, your model temperature.
+
+## The math, in one paragraph
+
+For each arm (variant), maintain two counters:
+
+- `successes` : how many times this arm "won" (a user converted, a session reached 8 messages, whatever your success criterion is)
+- `failures` : how many times this arm didn't win
+
+At decision time, for each arm, sample a random number from a `Beta(successes + 1, failures + 1)` distribution. The arm whose sample is highest wins this round.
+
+That's it. The Beta distribution naturally produces wide samples when you have little data (so under-explored arms get a chance), and tight samples when you have lots of data (so the winner consistently wins).
+
+## The code, in JavaScript
+
+```js
+function sampleBeta(alpha, beta) {
+	// Gamma sampling trick: Beta(a, b) = X / (X+Y) where X~Gamma(a), Y~Gamma(b)
+	const x = sampleGamma(alpha);
+	const y = sampleGamma(beta);
+	return x / (x + y);
+}
+
+function sampleGamma(shape) {
+	// Marsaglia & Tsang for shape >= 1; sufficient when we add 1 to counts
+	const d = shape - 1 / 3;
+	const c = 1 / Math.sqrt(9 * d);
+	while (true) {
+		let x, v;
+		do {
+			x = gaussian();
+			v = 1 + c * x;
+		} while (v <= 0);
+		v = v * v * v;
+		const u = Math.random();
+		if (u < 1 - 0.0331 * x * x * x * x) return d * v;
+		if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v;
+	}
+}
+
+function gaussian() {
+	const u = 1 - Math.random();
+	const v = Math.random();
+	return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function pickArm(arms) {
+	let best = null;
+	let bestScore = -Infinity;
+	for (const [name, { successes, failures }] of Object.entries(arms)) {
+		const score = sampleBeta(successes + 1, failures + 1);
+		if (score > bestScore) {
+			bestScore = score;
+			best = name;
+		}
+	}
+	return best;
+}
+```
+
+In production you'd want to use a library (`simple-statistics` has Beta sampling) but the above is enough to understand and run.
+
+## Wiring it into a product
+
+The pattern:
+
+1. Each user session is assigned an arm. Stamp the session with the arm name.
+2. When the session ends, you know whether it succeeded by your criterion (long enough, deep enough, converted, whatever).
+3. Each night, a script:
+   - Pulls the last 24h of sessions.
+   - Tallies success/failure per arm.
+   - Updates the arm counters in a state file.
+   - Samples once per arm, picks the winner, writes the recommendation.
+4. Your runtime reads the recommendation file and weights traffic accordingly. (Or assigns arms with weighted-random based on the posteriors directly.)
+
+Notice: there's no statistical test, no p-value, no "is the difference significant?" The Beta posterior *is* the significance. When one arm dominates, sampling rarely picks the others.
+
+## What "success" should be
+
+This is the part everyone gets wrong on their first bandit.
+
+Bad success criteria:
+
+- "User clicked the button." (One-shot, doesn't reflect downstream value.)
+- "User said yes in a survey." (Self-report is unreliable.)
+- "An LLM judge rated this 8/10." (See: the proxy-metric trap.)
+
+Good success criteria:
+
+- "Session duration ≥ 180 seconds AND message count ≥ 8."
+- "User returned within 7 days."
+- "Purchase completed in this session."
+- "Email reply received within 48 hours."
+
+The criterion should be:
+
+- **Boolean.** Yes-or-no per session. Bandit math is built on Bernoulli outcomes.
+- **Cheap.** Computed from data you already have.
+- **Tied to value.** Moving this number should mean the product got better.
+
+## The stability problem
+
+Thompson Sampling on thin data is volatile. With 5 sessions per arm, posteriors are wide and recommendations flip nightly. This is fine for the math : the algorithm is doing exactly what it should : but it's a disaster for human decision-making, because you'll have meetings about a winner that changes by Friday.
+
+The fix: record the recommendation every night in a TSV, and only consider an arm "STABLE" if:
+
+- It has been recommended for ≥5 consecutive nights, AND
+- The winner has ≥20 success-eligible sessions, AND
+- Its posterior probability of being best is ≥ 70%.
+
+Until all three hold, the bandit's recommendation is *information*, not a *decision*. Run, don't promote.
+
+## Failure modes nobody warns you about
+
+**1. Reward delay.** If conversion happens 7 days after the session, your bandit is making decisions on stale arms. Either define a faster proxy success, or hold the bandit's recommendations for 7 days before consuming them.
+
+**2. Drift.** If your user mix changes (e.g., a marketing campaign brings in a new cohort), an arm that was winning may stop winning, and your bandit will take time to notice. Periodically reset the counters to ~10% of current, so old data doesn't dominate forever.
+
+**3. Arm explosion.** Six arms is plenty. Twelve arms means each arm gets too few sessions per night to learn anything. If you want to test six factors, find a way to express it as one parameter at a time, not the Cartesian product.
+
+**4. Reward hacking.** If your success criterion is gameable, the bandit will find the game. "Session duration" is a classic example: any arm that confuses the user keeps them in-session longer.
+
+**5. Confounded arms.** If two of your "arms" are actually the same prompt with a typo, the bandit will detect no difference and split traffic forever. Make arms different in ways you can defend in a sentence.
+
+## When to use it, when not to
+
+**Use Thompson Sampling when:**
+
+- You have a continuous stream of users you can route between variants.
+- Success can be measured per session, in under a week, as a boolean.
+- The cost of running a "losing" arm is low.
+- You don't have a clean statistical sample size in mind anyway.
+
+**Don't use it when:**
+
+- The decision is one-shot and high-stakes (a redesign launch).
+- The variants are large, expensive engineering investments where you'd want a real A/B.
+- You need to *prove* a winner to a stakeholder who wants p-values. (Bandit results are believable but not formally significance-tested.)
+
+## A weekend project
+
+Take the lowest-stakes variant decision you have on your product. Write three arms. Implement the 30-line bandit above. Stamp sessions. Run it for two weeks.
+
+You will, with very high probability, end up with one of two outcomes:
+
+- One arm is clearly winning by week two. You'll have learned which.
+- All three arms are statistically indistinguishable. You'll have learned that too (and saved yourself shipping a "winner" that wasn't).
+
+Both outcomes are wins. The losing scenario : where you ran a bandit and learned nothing : almost doesn't exist, because *learning nothing is itself information*.

--- a/src/content/blog/web-performance-optimization.md
+++ b/src/content/blog/web-performance-optimization.md
@@ -1,0 +1,115 @@
+---
+title: "Web Performance Optimization: A Practical Guide"
+date: 2023-12-10
+readTime: 9 min read
+excerpt: Speed matters. Learn practical techniques to optimize your web applications for better performance, from lazy loading to code splitting and beyond.
+tags: [Performance, Web Development]
+featured: false
+---
+
+Performance is a feature. A page that loads in 800ms feels like a different product from one that loads in 3s : even though "both work." This is a practical guide to the techniques that move the needle, in roughly the order I reach for them.
+
+## Measure first
+
+Don't optimize what you haven't measured. Tools, in order of usefulness:
+
+- **Lighthouse** in Chrome DevTools. Five categories, scored 0–100. Run it on a throttled connection.
+- **WebPageTest.org** for real-device, real-network testing. The filmstrip is invaluable.
+- **Chrome Performance tab** for flame charts when something is slow but you don't know why.
+
+Your three target metrics:
+
+- **LCP (Largest Contentful Paint)** : under 2.5s. The thing the user came to see is on screen.
+- **CLS (Cumulative Layout Shift)** : under 0.1. Nothing jumps around as it loads.
+- **INP (Interaction to Next Paint)** : under 200ms. Clicks feel instant.
+
+## Ship less JavaScript
+
+The single biggest performance lever is shipping less code. Every kilobyte of JS costs more than the same kilobyte of HTML or CSS, because the browser has to parse and execute it.
+
+- **Audit your bundle.** `vite-bundle-visualizer` or similar. Look for surprises.
+- **Tree-shake aggressively.** Import `import { debounce } from 'lodash-es'`, not `import _ from 'lodash'`.
+- **Code split by route.** Each page should only load the JS it needs.
+- **Defer non-critical JS.** Analytics, chat widgets, ads : load them after the main content.
+
+## Lazy load images
+
+Above-the-fold images: eager.  
+Below-the-fold images: `loading="lazy"`.
+
+```html
+<img src="hero.jpg" alt="..." />
+<img src="story.jpg" alt="..." loading="lazy" />
+```
+
+This is built-in to the browser now. No library needed.
+
+## Modern image formats
+
+WebP is universally supported. AVIF is supported by 95% of browsers and is dramatically smaller for photographs.
+
+```html
+<picture>
+	<source srcset="photo.avif" type="image/avif" />
+	<source srcset="photo.webp" type="image/webp" />
+	<img src="photo.jpg" alt="..." />
+</picture>
+```
+
+The browser picks the first format it supports. The savings are often 50% over JPEG with no visible quality loss.
+
+## Reserve space for content
+
+Layout shift kills perceived performance. Always tell the browser how much space a thing will take:
+
+```html
+<img src="photo.jpg" width="800" height="600" alt="..." />
+```
+
+For dynamic content, use a skeleton with the correct dimensions. The page should look like the final layout from the first paint.
+
+## Cache aggressively
+
+For static assets, set a long `Cache-Control` and version the URL:
+
+```
+GET /assets/app.4f2c91.js
+Cache-Control: public, max-age=31536000, immutable
+```
+
+The hash in the filename means you can cache for a year. When the file changes, the hash changes, the URL changes, the cache invalidates. Free.
+
+## Use a CDN
+
+A CDN puts your static assets close to the user geographically. For an international audience, this is a much bigger win than micro-optimizing your server.
+
+## Preload critical resources
+
+If your hero font is essential to first paint, preload it:
+
+```html
+<link rel="preload" href="/fonts/main.woff2" as="font" type="font/woff2" crossorigin />
+```
+
+Same for above-the-fold images and critical CSS. Be sparing : preloading everything is the same as preloading nothing.
+
+## Server-side rendering (or static generation)
+
+The fastest page is one that arrives as already-rendered HTML. If your framework supports SSR or SSG, use it for content pages. Hydration costs are real, but they're less expensive than a blank screen.
+
+## Watch the third parties
+
+The slowest 10% of any production site is usually third-party scripts: analytics, ads, chat, A/B testing, fingerprinting. Each one has a budget. If a vendor's script blocks first paint, replace them.
+
+## A 30-minute audit you can do right now
+
+1. Run Lighthouse on your homepage with mobile throttling.
+2. Read the "Opportunities" section top-to-bottom.
+3. Pick the three that look cheapest. Implement them.
+4. Re-run Lighthouse.
+
+You will probably gain 10–20 points of score from changes that took an afternoon. After that, every gain takes ten times the work.
+
+## Conclusion
+
+Performance optimization is rarely about clever tricks. It's about shipping less, measuring honestly, and caching aggressively. Do the boring stuff first. Save the clever stuff for when boring isn't enough.

--- a/src/lib/articles.ts
+++ b/src/lib/articles.ts
@@ -1,0 +1,90 @@
+import { marked } from 'marked';
+
+export interface Article {
+	slug: string;
+	title: string;
+	date: string;
+	readTime: string;
+	excerpt: string;
+	tags: string[];
+	featured: boolean;
+	content: string;
+	contentHtml: string;
+}
+
+function parseFrontmatter(raw: string): { data: Record<string, unknown>; content: string } {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/.exec(raw);
+	if (!match) return { data: {}, content: raw };
+
+	const yamlBlock = match[1];
+	const content = match[2];
+	const data: Record<string, unknown> = {};
+
+	for (const line of yamlBlock.split(/\r?\n/)) {
+		const colonIdx = line.indexOf(':');
+		if (colonIdx === -1) continue;
+		const key = line.slice(0, colonIdx).trim();
+		const rawValue = line.slice(colonIdx + 1).trim();
+
+		if (rawValue.startsWith('[') && rawValue.endsWith(']')) {
+			const inner = rawValue.slice(1, -1).trim();
+			data[key] = inner
+				? inner.split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+				: [];
+		} else if (rawValue === 'true') {
+			data[key] = true;
+		} else if (rawValue === 'false') {
+			data[key] = false;
+		} else {
+			data[key] = rawValue.replace(/^['"]|['"]$/g, '');
+		}
+	}
+
+	return { data, content };
+}
+
+marked.setOptions({ gfm: true, breaks: false });
+
+const rawModules = import.meta.glob('/src/content/blog/*.md', {
+	eager: true,
+	query: '?raw',
+	import: 'default'
+}) as Record<string, string>;
+
+const articles: Article[] = Object.entries(rawModules)
+	.map(([path, raw]) => {
+		const slug = (path.split('/').pop() ?? '').replace(/\.md$/, '');
+		const { data, content } = parseFrontmatter(raw);
+		return {
+			slug,
+			title: (data.title as string) ?? slug,
+			date: (data.date as string) ?? '',
+			readTime: (data.readTime as string) ?? '',
+			excerpt: (data.excerpt as string) ?? '',
+			tags: (data.tags as string[]) ?? [],
+			featured: Boolean(data.featured),
+			content,
+			contentHtml: marked.parse(content, { async: false }) as string
+		};
+	})
+	.sort((a, b) => b.date.localeCompare(a.date));
+
+export function getArticles(): Article[] {
+	return articles;
+}
+
+export function getArticle(slug: string): Article | null {
+	return articles.find((a) => a.slug === slug) ?? null;
+}
+
+export function getAllTags(): string[] {
+	return [...new Set(articles.flatMap((a) => a.tags))].sort();
+}
+
+export function getArticlesByTag(tag: string): Article[] {
+	return articles.filter((a) => a.tags.includes(tag));
+}
+
+export function getFeaturedArticles(): Article[] {
+	return articles.filter((a) => a.featured);
+}

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,4 +1,9 @@
 <script lang="ts">
+	import { getArticles, getAllTags } from '$lib/articles';
+
+	const posts = getArticles();
+	const allTags = getAllTags();
+
 	function formatDate(dateStr: string) {
 		return new Date(dateStr).toLocaleDateString('en-US', {
 			year: 'numeric',
@@ -7,69 +12,19 @@
 		});
 	}
 
-	// Static blog posts for now - can be moved to a CMS or markdown files later
-	const posts = [
-		{
-			slug: 'getting-started-with-svelte-5',
-			title: 'Getting Started with Svelte 5: A Complete Guide',
-			excerpt: 'Explore the new features in Svelte 5, including runes, fine-grained reactivity, and improved performance. This comprehensive guide will help you understand and leverage the power of Svelte 5 in your projects.',
-			date: '2024-01-15',
-			readTime: '8 min read',
-			tags: ['Svelte', 'JavaScript', 'Tutorial'],
-			featured: true
-		},
-		{
-			slug: 'building-better-apis',
-			title: 'Building Better APIs: Best Practices for RESTful Design',
-			excerpt: 'Learn how to design clean, intuitive, and scalable REST APIs that developers love to use. We cover naming conventions, versioning, error handling, and more.',
-			date: '2024-01-08',
-			readTime: '6 min read',
-			tags: ['API', 'Backend', 'Best Practices'],
-			featured: true
-		},
-		{
-			slug: 'the-power-of-typescript',
-			title: 'The Power of TypeScript in Large-Scale Applications',
-			excerpt: 'Why TypeScript is essential for building maintainable applications and how to get the most out of it. Discover tips for better type safety and developer experience.',
-			date: '2024-01-01',
-			readTime: '5 min read',
-			tags: ['TypeScript', 'JavaScript'],
-			featured: false
-		},
-		{
-			slug: 'modern-css-techniques',
-			title: 'Modern CSS Techniques Every Developer Should Know',
-			excerpt: 'From CSS Grid and Flexbox to custom properties and container queries, explore the modern CSS features that make building responsive layouts easier than ever.',
-			date: '2023-12-20',
-			readTime: '7 min read',
-			tags: ['CSS', 'Frontend', 'Design'],
-			featured: false
-		},
-		{
-			slug: 'web-performance-optimization',
-			title: 'Web Performance Optimization: A Practical Guide',
-			excerpt: 'Speed matters. Learn practical techniques to optimize your web applications for better performance, from lazy loading to code splitting and beyond.',
-			date: '2023-12-10',
-			readTime: '9 min read',
-			tags: ['Performance', 'Web Development'],
-			featured: false
-		}
-	];
-
 	let selectedTag = $state<string | null>(null);
 
-	const allTags = [...new Set(posts.flatMap(p => p.tags))].sort();
-
 	const filteredPosts = $derived(
-		selectedTag
-			? posts.filter(p => p.tags.includes(selectedTag))
-			: posts
+		selectedTag ? posts.filter((p) => p.tags.includes(selectedTag!)) : posts
 	);
 </script>
 
 <svelte:head>
 	<title>Blog | Hiroyuki Kuwana</title>
-	<meta name="description" content="Articles about web development, software engineering, and technology by Hiroyuki Kuwana." />
+	<meta
+		name="description"
+		content="Articles about web development, AI workflows, and software engineering by Hiroyuki Kuwana."
+	/>
 </svelte:head>
 
 <section class="blog-page">
@@ -78,7 +33,7 @@
 			<span class="section-label">Blog</span>
 			<h1>Thoughts & Tutorials</h1>
 			<p class="subtitle">
-				Exploring web development, software engineering, and the technologies that power the modern web.
+				Exploring web development, AI workflows, and the technologies that power the modern web.
 			</p>
 		</header>
 
@@ -86,7 +41,7 @@
 			<button
 				class="filter-tag"
 				class:active={selectedTag === null}
-				onclick={() => selectedTag = null}
+				onclick={() => (selectedTag = null)}
 			>
 				All Posts
 			</button>
@@ -94,7 +49,7 @@
 				<button
 					class="filter-tag"
 					class:active={selectedTag === tag}
-					onclick={() => selectedTag = tag}
+					onclick={() => (selectedTag = tag)}
 				>
 					{tag}
 				</button>
@@ -102,7 +57,7 @@
 		</div>
 
 		<div class="posts-list">
-			{#each filteredPosts as post, i}
+			{#each filteredPosts as post, i (post.slug)}
 				<article class="post-item" style="animation-delay: {i * 0.1}s">
 					<div class="post-content">
 						<div class="post-meta">
@@ -123,18 +78,22 @@
 						<div class="post-footer">
 							<div class="post-tags">
 								{#each post.tags as tag}
-									<button
-										class="tag"
-										onclick={() => selectedTag = tag}
-									>
+									<button class="tag" onclick={() => (selectedTag = tag)}>
 										{tag}
 									</button>
 								{/each}
 							</div>
 							<a href="/blog/{post.slug}" class="read-more">
 								Read Article
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-									<path d="M5 12h14M12 5l7 7-7 7"/>
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+								>
+									<path d="M5 12h14M12 5l7 7-7 7" />
 								</svg>
 							</a>
 						</div>
@@ -146,7 +105,7 @@
 		{#if filteredPosts.length === 0}
 			<div class="no-posts">
 				<p>No posts found with the selected tag.</p>
-				<button class="btn btn-secondary" onclick={() => selectedTag = null}>
+				<button class="btn btn-secondary" onclick={() => (selectedTag = null)}>
 					View All Posts
 				</button>
 			</div>

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,144 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import { getArticle } from '$lib/articles';
 
-	// Static blog posts content
-	const posts: Record<string, {
-		title: string;
-		date: string;
-		readTime: string;
-		tags: string[];
-		content: string;
-	}> = {
-		'getting-started-with-svelte-5': {
-			title: 'Getting Started with Svelte 5: A Complete Guide',
-			date: '2024-01-15',
-			readTime: '8 min read',
-			tags: ['Svelte', 'JavaScript', 'Tutorial'],
-			content: `
-				<p>Svelte 5 introduces a revolutionary new way to handle reactivity in your applications. With the introduction of runes, Svelte has evolved from a compiler-based framework to something even more powerful and intuitive.</p>
-
-				<h2>What are Runes?</h2>
-				<p>Runes are special symbols that tell Svelte how to handle reactivity. The most important ones are:</p>
-				<ul>
-					<li><code>$state</code> - Declares reactive state</li>
-					<li><code>$derived</code> - Creates computed values</li>
-					<li><code>$effect</code> - Runs side effects when dependencies change</li>
-					<li><code>$props</code> - Declares component props</li>
-				</ul>
-
-				<h2>Creating Reactive State</h2>
-				<p>In Svelte 5, you create reactive state using the <code>$state</code> rune:</p>
-				<pre><code>let count = $state(0);
-
-function increment() {
-	count++;
-}</code></pre>
-
-				<h2>Derived Values</h2>
-				<p>When you need values that depend on other reactive values, use <code>$derived</code>:</p>
-				<pre><code>let count = $state(0);
-let doubled = $derived(count * 2);</code></pre>
-
-				<h2>Side Effects</h2>
-				<p>The <code>$effect</code> rune replaces the old <code>$:</code> reactive statements for side effects:</p>
-				<pre><code>$effect(() => {
-	console.log('Count changed:', count);
-});</code></pre>
-
-				<h2>Why This Matters</h2>
-				<p>These changes make Svelte more predictable and easier to reason about. The explicit nature of runes means you always know exactly what's reactive and what isn't.</p>
-
-				<h2>Conclusion</h2>
-				<p>Svelte 5 represents a significant step forward for the framework. The new runes system provides more explicit control over reactivity while maintaining the simplicity that makes Svelte so approachable.</p>
-			`
-		},
-		'building-better-apis': {
-			title: 'Building Better APIs: Best Practices for RESTful Design',
-			date: '2024-01-08',
-			readTime: '6 min read',
-			tags: ['API', 'Backend', 'Best Practices'],
-			content: `
-				<p>A well-designed API is a joy to work with. It's intuitive, consistent, and makes developers productive. Let's explore the best practices that separate good APIs from great ones.</p>
-
-				<h2>Use Nouns, Not Verbs</h2>
-				<p>Your endpoints should represent resources, not actions:</p>
-				<pre><code>// Good
-GET /users
-POST /users
-GET /users/123
-
-// Bad
-GET /getUsers
-POST /createUser
-GET /getUserById</code></pre>
-
-				<h2>Use HTTP Methods Correctly</h2>
-				<ul>
-					<li><strong>GET</strong> - Retrieve resources</li>
-					<li><strong>POST</strong> - Create new resources</li>
-					<li><strong>PUT</strong> - Update entire resources</li>
-					<li><strong>PATCH</strong> - Partial updates</li>
-					<li><strong>DELETE</strong> - Remove resources</li>
-				</ul>
-
-				<h2>Version Your API</h2>
-				<p>Always version your API from day one:</p>
-				<pre><code>https://api.example.com/v1/users
-https://api.example.com/v2/users</code></pre>
-
-				<h2>Handle Errors Gracefully</h2>
-				<p>Provide meaningful error responses:</p>
-				<pre><code>{
-	"error": {
-		"code": "VALIDATION_ERROR",
-		"message": "Email is required",
-		"field": "email"
-	}
-}</code></pre>
-
-				<h2>Conclusion</h2>
-				<p>Following these best practices will help you build APIs that developers love to use. Remember: the best API is one that's so intuitive, users barely need to read the documentation.</p>
-			`
-		},
-		'the-power-of-typescript': {
-			title: 'The Power of TypeScript in Large-Scale Applications',
-			date: '2024-01-01',
-			readTime: '5 min read',
-			tags: ['TypeScript', 'JavaScript'],
-			content: `
-				<p>TypeScript has become the de facto standard for large-scale JavaScript applications. But why? Let's explore what makes TypeScript so powerful.</p>
-
-				<h2>Catch Errors Early</h2>
-				<p>TypeScript catches errors at compile time, not runtime:</p>
-				<pre><code>function greet(name: string) {
-	return \`Hello, \${name}!\`;
-}
-
-greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
-
-				<h2>Better IDE Support</h2>
-				<p>With types, your IDE can provide intelligent autocomplete, refactoring tools, and inline documentation. This dramatically improves developer productivity.</p>
-
-				<h2>Self-Documenting Code</h2>
-				<p>Types serve as documentation that's always up-to-date:</p>
-				<pre><code>interface User {
-	id: string;
-	name: string;
-	email: string;
-	role: 'admin' | 'user';
-}</code></pre>
-
-				<h2>Refactoring with Confidence</h2>
-				<p>TypeScript makes refactoring safer. When you change a type, the compiler tells you everywhere that needs to be updated.</p>
-
-				<h2>Conclusion</h2>
-				<p>TypeScript's type system provides a safety net that becomes increasingly valuable as your application grows. The upfront investment in types pays dividends in fewer bugs and easier maintenance.</p>
-			`
-		}
-	};
-
-	const slug = $derived($page.params.slug);
-	const post = $derived(posts[slug]);
+	const slug = $derived($page.params.slug ?? '');
+	const post = $derived(slug ? getArticle(slug) : null);
 
 	function formatDate(dateStr: string) {
 		return new Date(dateStr).toLocaleDateString('en-US', {
@@ -152,7 +17,7 @@ greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
 <svelte:head>
 	{#if post}
 		<title>{post.title} | Hiroyuki Kuwana</title>
-		<meta name="description" content={post.title} />
+		<meta name="description" content={post.excerpt || post.title} />
 	{:else}
 		<title>Post Not Found | Hiroyuki Kuwana</title>
 	{/if}
@@ -163,8 +28,15 @@ greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
 		{#if post}
 			<header class="post-header">
 				<a href="/blog" class="back-link">
-					<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<path d="M19 12H5M12 19l-7-7 7-7"/>
+					<svg
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+					>
+						<path d="M19 12H5M12 19l-7-7 7-7" />
 					</svg>
 					Back to Blog
 				</a>
@@ -185,7 +57,7 @@ greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
 			</header>
 
 			<div class="post-content">
-				{@html post.content}
+				{@html post.contentHtml}
 			</div>
 
 			<footer class="post-footer">
@@ -193,17 +65,34 @@ greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
 					<img src="/images/selfPortrait.jpeg" alt="Hiroyuki Kuwana" class="author-image" />
 					<div class="author-info">
 						<h4>Written by Hiroyuki Kuwana</h4>
-						<p>Full Stack Developer passionate about building elegant solutions with modern web technologies.</p>
+						<p>
+							Full Stack Developer passionate about building elegant solutions with modern web
+							technologies.
+						</p>
 					</div>
 				</div>
 
 				<div class="share-section">
 					<span>Share this article:</span>
 					<div class="share-buttons">
-						<a href="https://twitter.com/intent/tweet?text={encodeURIComponent(post.title)}&url={encodeURIComponent(`https://hkuwana.com/blog/${slug}`)}" target="_blank" rel="noopener noreferrer" class="share-btn">
+						<a
+							href="https://twitter.com/intent/tweet?text={encodeURIComponent(
+								post.title
+							)}&url={encodeURIComponent(`https://hkuwana.com/blog/${slug}`)}"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="share-btn"
+						>
 							Twitter
 						</a>
-						<a href="https://www.linkedin.com/shareArticle?mini=true&url={encodeURIComponent(`https://hkuwana.com/blog/${slug}`)}&title={encodeURIComponent(post.title)}" target="_blank" rel="noopener noreferrer" class="share-btn">
+						<a
+							href="https://www.linkedin.com/shareArticle?mini=true&url={encodeURIComponent(
+								`https://hkuwana.com/blog/${slug}`
+							)}&title={encodeURIComponent(post.title)}"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="share-btn"
+						>
 							LinkedIn
 						</a>
 					</div>
@@ -305,6 +194,13 @@ greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
 		margin-bottom: var(--spacing-lg);
 	}
 
+	.post-content :global(h3) {
+		font-size: var(--font-size-xl);
+		color: var(--color-text-primary);
+		margin-top: var(--spacing-2xl);
+		margin-bottom: var(--spacing-md);
+	}
+
 	.post-content :global(p) {
 		margin-bottom: var(--spacing-lg);
 	}
@@ -321,14 +217,82 @@ greet(123); // Error: Argument of type 'number' is not assignable</code></pre>
 
 	.post-content :global(pre) {
 		margin-bottom: var(--spacing-lg);
+		padding: var(--spacing-lg);
+		background: var(--color-bg-tertiary);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		overflow-x: auto;
+		font-size: var(--font-size-sm);
+		line-height: 1.6;
 	}
 
 	.post-content :global(code) {
+		font-family: var(--font-mono);
 		font-size: 0.9em;
+		color: var(--color-accent-light);
+	}
+
+	.post-content :global(pre code) {
+		color: var(--color-text-primary);
+		background: transparent;
+		padding: 0;
+	}
+
+	.post-content :global(:not(pre) > code) {
+		padding: 0.1em 0.4em;
+		background: var(--color-bg-tertiary);
+		border-radius: var(--radius-sm);
 	}
 
 	.post-content :global(strong) {
 		color: var(--color-text-primary);
+	}
+
+	.post-content :global(blockquote) {
+		margin: var(--spacing-lg) 0;
+		padding-left: var(--spacing-lg);
+		border-left: 3px solid var(--color-accent);
+		color: var(--color-text-primary);
+		font-style: italic;
+	}
+
+	.post-content :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin-bottom: var(--spacing-lg);
+		font-size: var(--font-size-sm);
+	}
+
+	.post-content :global(thead) {
+		border-bottom: 1px solid var(--color-border-light);
+	}
+
+	.post-content :global(th),
+	.post-content :global(td) {
+		padding: var(--spacing-sm) var(--spacing-md);
+		text-align: left;
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.post-content :global(th) {
+		color: var(--color-text-primary);
+		font-weight: 600;
+	}
+
+	.post-content :global(a) {
+		color: var(--color-accent-light);
+		text-decoration: underline;
+		text-underline-offset: 3px;
+	}
+
+	.post-content :global(a:hover) {
+		color: var(--color-accent);
+	}
+
+	.post-content :global(hr) {
+		border: none;
+		border-top: 1px solid var(--color-border);
+		margin: var(--spacing-2xl) 0;
 	}
 
 	.post-footer {


### PR DESCRIPTION
Replaces the inline-HTML blog with a function-based markdown loader so new posts are just files. Adds eight AI/autoresearch articles distilled from the Kaiwa autoresearch README, fills in two previously stub posts, and migrates the three existing posts into the new format.